### PR TITLE
Updates the HUD after the world is loaded.

### DIFF
--- a/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Roton/Emulation/Core/Impl/Engine.cs
@@ -894,8 +894,6 @@ namespace Roton.Emulation.Core.Impl
                 return;
             }
             
-            Hud.CreateStatusWorld();
-
             using (var stream = new MemoryStream(worldData))
             {
                 if (stream.Length == 0)
@@ -925,6 +923,7 @@ namespace Roton.Emulation.Core.Impl
                 }
             }
 
+            Hud.CreateStatusWorld();
             UnpackBoard(World.BoardIndex);
             State.WorldLoaded = true;
         }


### PR DESCRIPTION
This corrects an issue where "Untitled" is always displayed as the world name when the default world is loaded.