### PR TITLE
Migrated to the DotSDL NuGet package.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "DotSDL"]
-	path = Source/DotSDL
-	url = git@github.com:Spectere/DotSDL.git

--- a/Source/Lyon/App/IWindow.cs
+++ b/Source/Lyon/App/IWindow.cs
@@ -3,7 +3,7 @@
     public interface IWindow
     {
         void SetSize(int width, int height);
-        void Start(int updateRate);
+        void Start(float updateRate);
         void Close();
     }
 }

--- a/Source/Lyon/App/Impl/Launcher.cs
+++ b/Source/Lyon/App/Impl/Launcher.cs
@@ -33,7 +33,7 @@ namespace Lyon.App.Impl
             AudioPresenter.Start();
             engine.Exited += OnExited;
             engine.Start();
-            Window.Start(14);
+            Window.Start(72.75f);
             engine.Stop();
             AudioPresenter.Stop();
         }

--- a/Source/Lyon/App/Impl/Window.cs
+++ b/Source/Lyon/App/Impl/Window.cs
@@ -17,7 +17,7 @@ namespace Lyon.App.Impl
 
         public int Width => WindowWidth;
         public int Height => WindowHeight;
-        
+
         private IKeyboardPresenter KeyboardPresenter => _keyboardPresenter.Value;
         private IScenePresenter ScenePresenter => _scenePresenter.Value;
 
@@ -33,6 +33,11 @@ namespace Lyon.App.Impl
             _scenePresenter = scenePresenter;
             KeyPressed += OnKeyDown;
             Closed += OnClosed;
+
+            Background.GetCanvasPointer = () => {
+                var bitmap = ScenePresenter.Render();
+                return bitmap.Bits.Length == 0 ? IntPtr.Zero : bitmap.BitsPointer;
+            };
         }
 
         private void OnClosed(object sender, WindowEvent e)
@@ -45,9 +50,9 @@ namespace Lyon.App.Impl
             ScenePresenter.UpdateViewport();
         }
 
-        public void Start(int updateRate)
+        public void Start(float updateRate)
         {
-            base.Start((uint) updateRate);
+            base.Start(updateRate);
         }
 
         public void Close()
@@ -60,13 +65,7 @@ namespace Lyon.App.Impl
             KeyboardPresenter.Press(e);
         }
 
-        public override IntPtr GetCanvasPointer()
-        {
-            var bitmap = ScenePresenter.Render();
-            return bitmap.Bits.Length == 0 ? IntPtr.Zero : bitmap.BitsPointer;
-        }
-
-        protected override void OnUpdate()
+        protected override void OnUpdate(float delta)
         {
             if(_closeWindow)
                 Stop();

--- a/Source/Lyon/Lyon.csproj
+++ b/Source/Lyon/Lyon.csproj
@@ -7,11 +7,11 @@
     <!--<RuntimeIdentifiers>win10-x64;osx.10.11-x64;ubuntu.16.04-x64</RuntimeIdentifiers>-->
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DotSDL\DotSDL\DotSDL.csproj" />
     <ProjectReference Include="..\Roton\Roton.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.1" />
+    <PackageReference Include="DotSDL" Version="0.0.1-alpha" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\Deploy\Config.json">

--- a/Source/Lyon/Program.cs
+++ b/Source/Lyon/Program.cs
@@ -39,14 +39,14 @@ namespace Lyon
             var contextEngine = selector.Get(fileName);
 
             var builder = new ContainerBuilder();
-            
+
             builder.RegisterInstance(config)
                 .As<IConfig>()
-                .SingleInstance();            
-            
+                .SingleInstance();
+
             builder.RegisterModule(new RotonModule(contextEngine));
             builder.RegisterModule(new LyonModule(args));
-            
+
             using (var container = builder.Build())
             {
                 container

--- a/Source/Roton.sln
+++ b/Source/Roton.sln
@@ -9,8 +9,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lyon", "Lyon\Lyon.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Roton.Test", "Roton.Test\Roton.Test.csproj", "{F87DC9C8-B22C-4A29-AB64-D529828950DE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotSDL", "DotSDL\DotSDL\DotSDL.csproj", "{91D97E4A-CA8C-4569-A5F2-52CD4DFAD3F1}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,10 +27,6 @@ Global
 		{F87DC9C8-B22C-4A29-AB64-D529828950DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F87DC9C8-B22C-4A29-AB64-D529828950DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F87DC9C8-B22C-4A29-AB64-D529828950DE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{91D97E4A-CA8C-4569-A5F2-52CD4DFAD3F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{91D97E4A-CA8C-4569-A5F2-52CD4DFAD3F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{91D97E4A-CA8C-4569-A5F2-52CD4DFAD3F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{91D97E4A-CA8C-4569-A5F2-52CD4DFAD3F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Now using the NuGet package instead of git submodules (yay!).
* Changed update frequency to hertz in order to target the latest DotSDL API.
* Migrated away from the obsolete GetCanvasPointer override from before to the new method (changing the function pointer on the canvas object itself).