### PR TITLE
Performance and accuracy improvements

### DIFF
--- a/Source/Roton.Test/Infrastructure/ContextBaseIntegrationTestFixture.cs
+++ b/Source/Roton.Test/Infrastructure/ContextBaseIntegrationTestFixture.cs
@@ -203,8 +203,8 @@ public abstract class ContextBaseIntegrationTestFixture(Context context) : BaseT
     protected ITile TileAt(IXyPair xy) =>
         Tiles[xy];
 
-    protected void Type(AnsiKey ekc, KeyMod mod = 0) =>
-        Keyboard.Press(new KeyPress { Key = ekc, Mod = mod });
+    protected void Type(AnsiKey key, KeyMod mod = 0) =>
+        Keyboard.Press(new KeyPress { Key = key, Mod = mod });
 
     protected int ActorIndexAt(int x, int y) =>
         Engine.ActorIndexAt(new Location(x, y));

--- a/Source/Roton.Test/Roton/Integration/Elements/PlayerTests.cs
+++ b/Source/Roton.Test/Roton/Integration/Elements/PlayerTests.cs
@@ -445,9 +445,33 @@ public class PlayerTests(Context context) : ElementTestFixture(context)
         Type(AnsiKey.Right);
         StepAllKeys();
 
+        // Assert.
         TileAt(4, 3).Id.Should().Be(ElementList.PlayerId,
             "player should have moved into boulder space");
         TileAt(5, 3).Id.Should().Be(ElementList.BoulderId,
             "boulder should have been pushed");
+    }
+
+    [Test]
+    public void Player_ShouldBeAbleToShootEnemiesPointBlank()
+    {
+        // Place the player.
+        MovePlayerTo(10, 10);
+        
+        // Give the player some ammo.
+        World.Ammo = 1;
+        
+        // Place an enemy.
+        SpawnTo(11, 10, ElementList.LionId);
+        
+        // Instruct the player to shoot the enemy.
+        Type(AnsiKey.Right, KeyMod.Shift);
+        StepAllKeys();
+        
+        // Assert.
+        World.Ammo.Should().Be(0,
+            "player should have used ammo");
+        TileAt(11, 10).Id.Should().Be(ElementList.EmptyId,
+            "enemy should have been killed");
     }
 }

--- a/Source/Roton.Test/Roton/Integration/Elements/PlayerTests.cs
+++ b/Source/Roton.Test/Roton/Integration/Elements/PlayerTests.cs
@@ -457,21 +457,44 @@ public class PlayerTests(Context context) : ElementTestFixture(context)
     {
         // Place the player.
         MovePlayerTo(10, 10);
-        
+
         // Give the player some ammo.
         World.Ammo = 1;
-        
+
         // Place an enemy.
         SpawnTo(11, 10, ElementList.LionId);
-        
+
         // Instruct the player to shoot the enemy.
         Type(AnsiKey.Right, KeyMod.Shift);
         StepAllKeys();
-        
+
         // Assert.
         World.Ammo.Should().Be(0,
             "player should have used ammo");
         TileAt(11, 10).Id.Should().Be(ElementList.EmptyId,
             "enemy should have been killed");
+    }
+
+    [Test]
+    public void Player_ShouldBeAbleToShootBreakablesPointBlank()
+    {
+        // Place the player.
+        MovePlayerTo(10, 10);
+
+        // Give the player some ammo.
+        World.Ammo = 1;
+
+        // Place a breakable wall.
+        PlotTo(11, 10, ElementList.BreakableId);
+
+        // Instruct the player to shoot the wall.
+        Type(AnsiKey.Right, KeyMod.Shift);
+        StepAllKeys();
+
+        // Assert.
+        World.Ammo.Should().Be(0,
+            "player should have used ammo");
+        TileAt(11, 10).Id.Should().Be(ElementList.EmptyId,
+            "breakable wall should have been broken");
     }
 }

--- a/Source/Roton/Composers/Video/Glyphs/Impl/Glyph.cs
+++ b/Source/Roton/Composers/Video/Glyphs/Impl/Glyph.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Roton.Composers.Video.Glyphs.Impl;
 

--- a/Source/Roton/Composers/Video/Palettes/Impl/CachedPaletteComposer.cs
+++ b/Source/Roton/Composers/Video/Palettes/Impl/CachedPaletteComposer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using System.Linq;
 using Roton.Composers.Extensions;
 
 namespace Roton.Composers.Video.Palettes.Impl;

--- a/Source/Roton/Emulation/Actions/Impl/ActionList.cs
+++ b/Source/Roton/Emulation/Actions/Impl/ActionList.cs
@@ -13,11 +13,13 @@ public sealed class ActionList : IActionList
     private readonly Lazy<IDictionary<int, IAction>> _actions;
     private IDictionary<int, IAction> Actions => _actions.Value;
 
-    public ActionList(Lazy<IContextMetadataService> contextMetadataService, Lazy<IEnumerable<IAction>> actions)
+    public ActionList(Lazy<IContextMetadataService> contextMetadataService, 
+        Lazy<IEnumerable<IAction>> actions)
     {
         _actions = new Lazy<IDictionary<int, IAction>>(() =>
         {
             var result = new Dictionary<int, IAction>();
+
             foreach (var action in actions.Value)
             {
                 foreach (var attribute in contextMetadataService.Value.GetMetadata(action))
@@ -27,10 +29,9 @@ public sealed class ActionList : IActionList
             return result;
         });
     }
-        
+
     public IAction Get(int index)
     {
         return Actions.ContainsKey(index) ? Actions[index] : Actions[-1];
     }
-
 }

--- a/Source/Roton/Emulation/Cheats/ICheat.cs
+++ b/Source/Roton/Emulation/Cheats/ICheat.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Roton.Emulation.Cheats;
 
 public interface ICheat
 {
-    void Execute(string name, bool clear);
+    void Execute(ReadOnlySpan<char> name, bool clear);
 }

--- a/Source/Roton/Emulation/Cheats/ICheatList.cs
+++ b/Source/Roton/Emulation/Cheats/ICheatList.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Roton.Emulation.Cheats;
 
 public interface ICheatList
 {
-    ICheat Get(string name);
+    ICheat Get(ReadOnlySpan<char> name);
 }

--- a/Source/Roton/Emulation/Cheats/Impl/AmmoCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/AmmoCheat.cs
@@ -13,7 +13,7 @@ public sealed class AmmoCheat(Lazy<IEngine> engine, Lazy<IFacts> facts) : ICheat
     private IEngine Engine => engine.Value;
     private IFacts Facts => facts.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.World.Ammo += Facts.AmmoPerPickup;
     }

--- a/Source/Roton/Emulation/Cheats/Impl/CheatList.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/CheatList.cs
@@ -11,8 +11,10 @@ namespace Roton.Emulation.Cheats.Impl;
 public sealed class CheatList : ICheatList
 {
     private readonly Lazy<IDictionary<string, ICheat>> _cheats;
+    private IDictionary<string, ICheat> Cheats => _cheats.Value;
 
-    public CheatList(Lazy<IContextMetadataService> contextMetadataService, Lazy<IEnumerable<ICheat>> cheats)
+    public CheatList(Lazy<IContextMetadataService> contextMetadataService, 
+        Lazy<IEnumerable<ICheat>> cheats)
     {
         _cheats = new Lazy<IDictionary<string, ICheat>>(() =>
         {
@@ -28,12 +30,14 @@ public sealed class CheatList : ICheatList
         });
     }
 
-    private IDictionary<string, ICheat> Cheats => _cheats.Value;
-
-    public ICheat Get(string name)
+    public ICheat Get(ReadOnlySpan<char> name)
     {
-        return Cheats.ContainsKey(name)
-            ? Cheats[name]
-            : null;
+        foreach (var entry in Cheats)
+        {
+            if (name.Equals(entry.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        return null;
     }
 }

--- a/Source/Roton/Emulation/Cheats/Impl/DarkCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/DarkCheat.cs
@@ -10,7 +10,7 @@ public sealed class DarkCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.Board.IsDark = !clear;
         Engine.Hud.RedrawBoard();

--- a/Source/Roton/Emulation/Cheats/Impl/GemsCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/GemsCheat.cs
@@ -11,7 +11,7 @@ public sealed class GemsCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.World.Gems += 5;
     }

--- a/Source/Roton/Emulation/Cheats/Impl/HealthCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/HealthCheat.cs
@@ -11,7 +11,7 @@ public sealed class HealthCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.World.Health += 50;
     }

--- a/Source/Roton/Emulation/Cheats/Impl/KeysCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/KeysCheat.cs
@@ -11,7 +11,7 @@ public sealed class KeysCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         for (var i = 0; i < 7; i++)
             Engine.World.Keys[i] = true;

--- a/Source/Roton/Emulation/Cheats/Impl/NoZCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/NoZCheat.cs
@@ -10,7 +10,7 @@ public sealed class NoZCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.World.Stones = -1;
     }

--- a/Source/Roton/Emulation/Cheats/Impl/TimeCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/TimeCheat.cs
@@ -11,7 +11,7 @@ public sealed class TimeCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.World.TimePassed -= 30;
     }

--- a/Source/Roton/Emulation/Cheats/Impl/TorchesCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/TorchesCheat.cs
@@ -10,7 +10,7 @@ public sealed class TorchesCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.World.Torches += 3;
     }

--- a/Source/Roton/Emulation/Cheats/Impl/ZCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/ZCheat.cs
@@ -10,7 +10,7 @@ public sealed class ZCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         Engine.World.Stones++;
     }

--- a/Source/Roton/Emulation/Cheats/Impl/ZapCheat.cs
+++ b/Source/Roton/Emulation/Cheats/Impl/ZapCheat.cs
@@ -11,7 +11,7 @@ public sealed class ZapCheat(Lazy<IEngine> engine) : ICheat
 {
     private IEngine Engine => engine.Value;
 
-    public void Execute(string name, bool clear)
+    public void Execute(ReadOnlySpan<char> name, bool clear)
     {
         for (var i = 0; i < 4; i++)
         {

--- a/Source/Roton/Emulation/Commands/ICommandList.cs
+++ b/Source/Roton/Emulation/Commands/ICommandList.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Roton.Emulation.Commands;
 
 public interface ICommandList
 {
-    ICommand Get(string name);
+    ICommand Get(ReadOnlySpan<char> name);
 }

--- a/Source/Roton/Emulation/Commands/Impl/CommandList.cs
+++ b/Source/Roton/Emulation/Commands/Impl/CommandList.cs
@@ -29,8 +29,8 @@ public sealed class CommandList : ICommandList
         
     public ICommand Get(string name)
     {
-        return _commands.Value.ContainsKey(name)
-            ? _commands.Value[name]
+        return _commands.Value.TryGetValue(name, out var value)
+            ? value
             : null;
     }        
 }

--- a/Source/Roton/Emulation/Commands/Impl/CommandList.cs
+++ b/Source/Roton/Emulation/Commands/Impl/CommandList.cs
@@ -11,12 +11,15 @@ namespace Roton.Emulation.Commands.Impl;
 public sealed class CommandList : ICommandList
 {
     private readonly Lazy<IDictionary<string, ICommand>> _commands;
+    private IDictionary<string, ICommand> Commands => _commands.Value;
 
-    public CommandList(Lazy<IContextMetadataService> contextMetadataService, Lazy<IEnumerable<ICommand>> commands)
+    public CommandList(Lazy<IContextMetadataService> contextMetadataService, 
+        Lazy<IEnumerable<ICommand>> commands)
     {
         _commands = new Lazy<IDictionary<string, ICommand>>(() =>
         {
             var result = new Dictionary<string, ICommand>();
+
             foreach (var command in commands.Value)
             {
                 foreach (var attribute in contextMetadataService.Value.GetMetadata(command))
@@ -26,11 +29,15 @@ public sealed class CommandList : ICommandList
             return result;
         });
     }
-        
-    public ICommand Get(string name)
+
+    public ICommand Get(ReadOnlySpan<char> name)
     {
-        return _commands.Value.TryGetValue(name, out var value)
-            ? value
-            : null;
-    }        
+        foreach (var entry in Commands)
+        {
+            if (name.Equals(entry.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        return null;
+    }
 }

--- a/Source/Roton/Emulation/Conditions/IConditionList.cs
+++ b/Source/Roton/Emulation/Conditions/IConditionList.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Roton.Emulation.Conditions;
 
 public interface IConditionList
 {
-    ICondition Get(string name);
+    ICondition Get(ReadOnlySpan<char> name);
 }

--- a/Source/Roton/Emulation/Conditions/Impl/ConditionList.cs
+++ b/Source/Roton/Emulation/Conditions/Impl/ConditionList.cs
@@ -11,12 +11,15 @@ namespace Roton.Emulation.Conditions.Impl;
 public sealed class ConditionList : IConditionList
 {
     private readonly Lazy<IDictionary<string, ICondition>> _conditions;
+    private IDictionary<string, ICondition> Conditions => _conditions.Value;
 
-    public ConditionList(Lazy<IContextMetadataService> contextMetadataService, Lazy<IEnumerable<ICondition>> conditions)
+    public ConditionList(Lazy<IContextMetadataService> contextMetadataService,
+        Lazy<IEnumerable<ICondition>> conditions)
     {
         _conditions = new Lazy<IDictionary<string, ICondition>>(() =>
         {
             var result = new Dictionary<string, ICondition>();
+
             foreach (var condition in conditions.Value)
             {
                 foreach (var attribute in contextMetadataService.Value.GetMetadata(condition))
@@ -26,11 +29,15 @@ public sealed class ConditionList : IConditionList
             return result;
         });
     }
-        
-    public ICondition Get(string name)
+
+    public ICondition Get(ReadOnlySpan<char> name)
     {
-        return _conditions.Value.TryGetValue(name, out var value)
-            ? value
-            : null;
-    }        
+        foreach (var entry in Conditions)
+        {
+            if (name.Equals(entry.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        return null;
+    }
 }

--- a/Source/Roton/Emulation/Conditions/Impl/ConditionList.cs
+++ b/Source/Roton/Emulation/Conditions/Impl/ConditionList.cs
@@ -29,8 +29,8 @@ public sealed class ConditionList : IConditionList
         
     public ICondition Get(string name)
     {
-        return _conditions.Value.ContainsKey(name)
-            ? _conditions.Value[name]
+        return _conditions.Value.TryGetValue(name, out var value)
+            ? value
             : null;
     }        
 }

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Roton.Emulation.Actions;
 using Roton.Emulation.Cheats;

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -1325,7 +1325,8 @@ public sealed class Engine : IEngine, IDisposable
 
         if (element.Id != ElementList.BreakableId &&
             (!element.IsDestructible ||
-             (element.Id != ElementList.PlayerId || World.EnergyCycles != 0) && enemyOwned))
+             element.Id == ElementList.PlayerId != enemyOwned ||
+             World.EnergyCycles != 0))
             return false;
 
         Destroy(target);

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -550,7 +550,7 @@ public sealed class Engine : IEngine, IDisposable
                     Interpreter.Execute(context);
                     break;
                 case 0x0D: // enter
-                    if (context.Message.Count > 0)
+                    if (context.HasMessage)
                         context.Message.Add(string.Empty);
                     break;
                 case 0x00:
@@ -575,7 +575,7 @@ public sealed class Engine : IEngine, IDisposable
         if (State.OopByte == 0)
             context.Instruction = -1;
 
-        if (context.Message.Count > 0)
+        if (context.HasMessage)
             ExecuteMessage(context);
 
         if (context.Died)

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -191,7 +191,7 @@ public sealed class Engine : IEngine, IDisposable
 
     public void Cheat()
     {
-        var cheatText = Hud.EnterCheat().ToUpper();
+        var cheatText = Hud.EnterCheat().UpCased();
         var clear = false;
 
         if (!ThreadActive)
@@ -618,7 +618,7 @@ public sealed class Engine : IEngine, IDisposable
 
         while (success)
         {
-            if (label.ToUpper() == Facts.RestartLabel)
+            if (label.UpCased() == Facts.RestartLabel)
             {
                 context.SearchOffset = 0;
             }

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -1572,7 +1572,7 @@ public sealed class Engine : IEngine, IDisposable
     private void ExecuteMessage(IOopContext context)
     {
         var result = Features.ExecuteMessage(context);
-        if (result is { Cancelled: false, Label: { } })
+        if (result is { Cancelled: false, Label: not null })
             context.NextLine = BroadcastLabel(context.Index, result.Label, false);
     }
 

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using System.Threading;
 using Roton.Emulation.Actions;
 using Roton.Emulation.Cheats;
@@ -58,6 +59,7 @@ public sealed class Engine : IEngine, IDisposable
     private readonly Lazy<IInterpreter> _interpreter;
     private readonly Lazy<IItemList> _items;
     private readonly Lazy<IKeyboard> _keyboard;
+    private readonly Lazy<IOopContextPool> _oopContextPool;
     private readonly Lazy<IParser> _parser;
     private readonly Lazy<IRandomizer> _randomizer;
     private readonly Lazy<ISounds> _sounds;
@@ -80,19 +82,20 @@ public sealed class Engine : IEngine, IDisposable
         Lazy<IWorld> world, Lazy<IItemList> items, Lazy<IBoards> boards, Lazy<IActionList> actionList,
         Lazy<IDrawList> drawList, Lazy<IInteractionList> interactionList, Lazy<IFacts> facts, Lazy<IMemory> memory,
         Lazy<IHeap> heap, Lazy<IAnsiKeyTransformer> ansiKeyTransformer, Lazy<IScrollFormatter> scrollFormatter,
-        Lazy<ISpeaker> speaker, Lazy<IDrumBank> drumBank, Lazy<IObjectMover> objectMover, Lazy<IMusicEncoder> musicEncoder,
+        Lazy<ISpeaker> speaker, Lazy<IDrumBank> drumBank, Lazy<IObjectMover> objectMover,
+        Lazy<IMusicEncoder> musicEncoder,
         Lazy<IHighScoreListFactory> highScoreListFactory, Lazy<IConfigFileService> configFileService,
-        Lazy<IFileDialog> fileDialog, Lazy<ITracer> tracer)
+        Lazy<IFileDialog> fileDialog, Lazy<ITracer> tracer, Lazy<IOopContextPool> oopContextPool)
     {
         _clock = new Lazy<IClock>(() =>
         {
             var clock = clockFactory.Value.Create(
-                _config.Value.MasterClockNumerator, 
+                _config.Value.MasterClockNumerator,
                 _config.Value.MasterClockDenominator);
-                
+
             if (clock != null)
                 clock.OnTick += ClockTick;
-                
+
             return clock;
         });
 
@@ -138,12 +141,13 @@ public sealed class Engine : IEngine, IDisposable
         _configFileService = configFileService;
         _fileDialog = fileDialog;
         _tracer = tracer;
+        _oopContextPool = oopContextPool;
     }
 
     private void ClockTick(object sender, EventArgs args)
     {
         if (_ticksToRun < 3) _ticksToRun++;
-        if (!ThreadActive) 
+        if (!ThreadActive)
             Clock.Stop();
     }
 
@@ -152,7 +156,7 @@ public sealed class Engine : IEngine, IDisposable
     private IObjectMover ObjectMover => _objectMover.Value;
 
     public IMusicEncoder MusicEncoder => _musicEncoder.Value;
-        
+
     private IClock Clock => _clock.Value;
 
     private IBoards Boards => _boards.Value;
@@ -174,7 +178,7 @@ public sealed class Engine : IEngine, IDisposable
     private IScrollFormatter ScrollFormatter => _scrollFormatter.Value;
 
     public ITimers Timers => _timers.Value;
-        
+
     public IDrumBank DrumBank => _drumBank.Value;
 
     public ITracer Tracer => _tracer.Value;
@@ -184,7 +188,7 @@ public sealed class Engine : IEngine, IDisposable
     public bool ThreadActive => Thread != null || _step;
 
     public int MemoryUsage => Features.BaseMemoryUsage + Heap.Size + Boards.Sum(b => b.Data.Length);
-        
+
     public void Cheat()
     {
         var cheatText = Hud.EnterCheat().ToUpper();
@@ -208,11 +212,11 @@ public sealed class Engine : IEngine, IDisposable
                 World.Flags.Add(cheatText);
             }
         }
-            
+
         var cheat = CheatList.Get(cheatText);
         cheat?.Execute(cheatText, clear);
         Hud.UpdateStatus();
-            
+
         // TODO: figure out the actual priority of this sound
         PlaySound(3, Sounds.Cheat);
     }
@@ -226,13 +230,13 @@ public sealed class Engine : IEngine, IDisposable
     }
 
     public string GetHighScoreName(string fileName) => Features.GetHighScoreName(fileName);
-        
+
     public void ShowHighScores()
     {
         var list = HighScoreListFactory.Load();
-        if (list == null) 
+        if (list == null)
             return;
-            
+
         Hud.ShowHighScores(list);
     }
 
@@ -261,7 +265,7 @@ public sealed class Engine : IEngine, IDisposable
 
     public event EventHandler Exited;
     public event EventHandler Tick;
-        
+
     public IActors Actors => _actors.Value;
 
     public int Adjacent(IXyPair location, int id)
@@ -323,9 +327,9 @@ public sealed class Engine : IEngine, IDisposable
         {
             if (!ActorIsLocked(info.SearchIndex) || ignoreLock || sender == info.SearchIndex && !ignoreSelfLock)
             {
-                if (sender == info.SearchIndex) 
+                if (sender == info.SearchIndex)
                     success = true;
-                
+
                 Tracer.TraceBroadcast(sender, label, info.SearchIndex, ignoreLock, ignoreSelfLock);
                 Actors[info.SearchIndex].Instruction = info.SearchOffset;
                 NotifyActorSentLabel(info.SearchIndex);
@@ -498,15 +502,11 @@ public sealed class Engine : IEngine, IDisposable
 
     public void ExecuteCode(int index, IExecutable instructionSource, string name)
     {
-        var context = new OopContext(index, instructionSource, name, this)
-        {
-            Moved = false,
-            Repeat = false,
-            Died = false,
-            Finished = false,
-            CommandsExecuted = 0
-        };
+        var context = OopContextPool.Rent();
 
+        context.Index = index;
+        context.InstructionSource = instructionSource;
+        context.Name = name;
         context.PreviousInstruction = context.Instruction;
 
         while (true)
@@ -515,7 +515,7 @@ public sealed class Engine : IEngine, IDisposable
                 break;
 
             Tracer?.TraceOop(context);
-                
+
             context.NextLine = true;
             context.PreviousInstruction = context.Instruction;
             context.Command = ReadActorCodeByte(index, context);
@@ -550,7 +550,7 @@ public sealed class Engine : IEngine, IDisposable
                     Interpreter.Execute(context);
                     break;
                 case 0x0D: // enter
-                    if (context.HasMessage)
+                    if (context.Message.Count > 0)
                         context.Message.Add(string.Empty);
                     break;
                 case 0x00:
@@ -580,6 +580,8 @@ public sealed class Engine : IEngine, IDisposable
 
         if (context.Died)
             CleanUpOop(context);
+
+        OopContextPool.Return(context);
     }
 
     public void CleanUpOop(IOopContext context) => Features.CleanUpOop(context);
@@ -591,7 +593,7 @@ public sealed class Engine : IEngine, IDisposable
         var split = label.IndexOf(':');
         string target = null;
 
-        bool NextStat() => 
+        bool NextStat() =>
             Parser.GetTarget(sender, context, target);
 
         if (split > 0)
@@ -607,7 +609,7 @@ public sealed class Engine : IEngine, IDisposable
             split = 0;
             success = true;
         }
-        
+
         while (success)
         {
             if (label.ToUpper() == Facts.RestartLabel)
@@ -623,11 +625,11 @@ public sealed class Engine : IEngine, IDisposable
                     continue;
                 }
             }
-        
+
             success = context.SearchOffset >= 0;
             break;
         }
-        
+
         return success;
     }
 
@@ -767,7 +769,8 @@ public sealed class Engine : IEngine, IDisposable
 
     public IItemList ItemList => _items.Value;
 
-    private void ShowFormattedScroll(string error) => Hud.ShowScroll(false, "Roton Error", ScrollFormatter.Format(error));
+    private void ShowFormattedScroll(string error) =>
+        Hud.ShowScroll(false, "Roton Error", ScrollFormatter.Format(error));
 
     public void LoadWorld(string name, bool savedGame)
     {
@@ -791,7 +794,7 @@ public sealed class Engine : IEngine, IDisposable
             ShowDosError();
             return;
         }
-            
+
         using (var stream = new MemoryStream(worldData))
         {
             if (stream.Length == 0)
@@ -904,7 +907,7 @@ public sealed class Engine : IEngine, IDisposable
             vector.SetTo(0, 1);
         else if (underId == ElementList.RiverWId)
             vector.SetTo(-1, 0);
-        else if (underId == ElementList.RiverEId) 
+        else if (underId == ElementList.RiverEId)
             vector.SetTo(1, 0);
 
         if (vector.IsNonZero())
@@ -913,19 +916,21 @@ public sealed class Engine : IEngine, IDisposable
             if (actorTile.Id == ElementList.PlayerId)
             {
                 var targetLocation = actor.Location.Sum(vector);
-                InteractionList.Get(Tiles[targetLocation].Id).Interact(targetLocation, 0, vector);                
+                InteractionList.Get(Tiles[targetLocation].Id).Interact(targetLocation, 0, vector);
             }
         }
-            
+
         if (vector.IsNonZero())
         {
             var target = actor.Location.Sum(vector);
-            if (ElementAt(target).IsFloor) 
+            if (ElementAt(target).IsFloor)
                 MoveActor(index, target);
         }
     }
 
     public void NotifyActorSentLabel(int index) => Features.NotifyActorSentLabel(index);
+
+    public IOopContextPool OopContextPool => _oopContextPool.Value;
 
     public IParser Parser => _parser.Value;
 
@@ -1156,7 +1161,7 @@ public sealed class Engine : IEngine, IDisposable
         using var writer = new BinaryWriter(stream);
 
         // Write common world header.
-        
+
         var type = (short)World.WorldType;
         var numBoards = (short)(Boards.Count - 1);
 
@@ -1168,7 +1173,7 @@ public sealed class Engine : IEngine, IDisposable
         GameSerializer.SaveWorld(stream);
 
         // Write each packed board.
-        
+
         foreach (var board in Boards)
             GameSerializer.SaveBoardData(stream, board.Data);
 
@@ -1239,7 +1244,7 @@ public sealed class Engine : IEngine, IDisposable
     public void OpenWorld()
     {
         var name = Features.OpenWorld();
-        if (string.IsNullOrEmpty(name)) 
+        if (string.IsNullOrEmpty(name))
             return;
 
         LoadWorld(name, false);
@@ -1251,7 +1256,7 @@ public sealed class Engine : IEngine, IDisposable
     public bool RestoreWorld()
     {
         var name = Features.RestoreWorld();
-        if (string.IsNullOrEmpty(name)) 
+        if (string.IsNullOrEmpty(name))
             return false;
 
         LoadWorld(name, true);
@@ -1395,7 +1400,7 @@ public sealed class Engine : IEngine, IDisposable
 
     private void UpdateSound()
     {
-        if (!State.SoundPlaying) 
+        if (!State.SoundPlaying)
             return;
 
         if (State.SoundTicks <= 0)
@@ -1406,16 +1411,16 @@ public sealed class Engine : IEngine, IDisposable
                 State.SoundTicks = sound.Duration << 2;
                 if (sound.Note >= 0xF0)
                 {
-                    Speaker.PlayDrum(sound.Note - 0xF0);                                
+                    Speaker.PlayDrum(sound.Note - 0xF0);
                 }
                 else if (sound.Note > 0x00)
                 {
                     var actualNote = (sound.Note & 0xF) + (sound.Note >> 4) * 12;
-                    Speaker.PlayNote(actualNote);                                
+                    Speaker.PlayNote(actualNote);
                 }
                 else
                 {
-                    Speaker.StopNote();                                
+                    Speaker.StopNote();
                 }
             }
             else
@@ -1445,21 +1450,21 @@ public sealed class Engine : IEngine, IDisposable
                 if (Clock != null)
                     Tick?.Invoke(this, EventArgs.Empty);
                 _ticksToRun--;
-                
+
                 return false;
             });
         }
         else
         {
             UpdateSound();
-                
+
             if (Clock == null)
                 return;
-            
+
             Tick?.Invoke(this, EventArgs.Empty);
 
             SpinWait.SpinUntil(() => _ticksToRun > 0 || !ThreadActive);
-            
+
             if (_ticksToRun > 0)
                 _ticksToRun--;
         }
@@ -1549,13 +1554,13 @@ public sealed class Engine : IEngine, IDisposable
     private void EnterHighScore(int score)
     {
         var list = HighScoreListFactory.Load();
-        if (list == null) 
+        if (list == null)
             return;
-            
+
         var name = Hud.EnterHighScore(list, score);
-        if (name == null) 
+        if (name == null)
             return;
-            
+
         list.Add(name, score);
         HighScoreListFactory.Save(list);
         ShowHighScores();
@@ -1565,7 +1570,7 @@ public sealed class Engine : IEngine, IDisposable
     {
         var result = Features.ExecuteMessage(context);
         if (result is { Cancelled: false, Label: { } })
-            context.NextLine = BroadcastLabel(context.Index, result.Label, false);                            
+            context.NextLine = BroadcastLabel(context.Index, result.Label, false);
     }
 
     private void FadeBoard(AnsiChar ac) => Hud.FadeBoard(ac);
@@ -1796,7 +1801,7 @@ public sealed class Engine : IEngine, IDisposable
         if (World.IsLocked)
         {
             LoadWorld(World.Name, false);
-                
+
             if (State.WorldLoaded)
             {
                 gameIsActive = State.WorldLoaded;
@@ -1844,9 +1849,9 @@ public sealed class Engine : IEngine, IDisposable
             return EngineKeyCode.None;
 
         if (bytes.Count > 1 && (bytes[0] == 0 || bytes[0] >= 0x80))
-            return (EngineKeyCode) (bytes[1] | 0x80);
+            return (EngineKeyCode)(bytes[1] | 0x80);
 
-        return (EngineKeyCode) bytes[0];
+        return (EngineKeyCode)bytes[0];
     }
 
     public void ReadInput()

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -519,12 +519,18 @@ public sealed class Engine : IEngine, IDisposable
             context.NextLine = true;
             context.PreviousInstruction = context.Instruction;
             context.Command = ReadActorCodeByte(index, context);
+
+            while (context.Command == ':')
+            {
+                Parser.DiscardLine(index, context);
+                context.Command = ReadActorCodeByte(index, context);
+            }
+
             switch (context.Command)
             {
-                case 0x3A: // :
                 case 0x27: // '
                 case 0x40: // @
-                    Parser.ReadLine(index, context);
+                    Parser.DiscardLine(index, context);
                     break;
                 case 0x2F: // /
                 case 0x3F: // ?

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -725,18 +725,15 @@ public sealed class Engine : IEngine, IDisposable
                 World.Health -= Facts.HealthLostPerHit;
                 UpdateStatus();
                 SetMessage(Facts.ShortMessageDuration, Alerts.OuchMessage);
-                var color = Tiles[actor.Location].Color;
-                color &= 0x0F;
-                color |= 0x70;
-                Tiles[actor.Location].Color = color;
+                Tiles[actor.Location].Color = (ElementAt(actor.Location).Color & 0x0F) | 0x70;
+
                 if (World.Health > 0)
                 {
                     World.TimePassed = 0;
                     if (Board.RestartOnZap)
                     {
                         PlaySound(4, Sounds.TimeOut);
-                        Tiles[actor.Location].Id = ElementList.EmptyId;
-                        UpdateBoard(actor.Location);
+                        RemoveItem(actor.Location);
                         var oldLocation = actor.Location.Clone();
                         actor.Location.CopyFrom(Board.Entrance);
                         UpdateRadius(oldLocation, 0);

--- a/Source/Roton/Emulation/Core/Impl/FixedFileSystem.cs
+++ b/Source/Roton/Emulation/Core/Impl/FixedFileSystem.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Roton.Emulation.Core.Impl;
 

--- a/Source/Roton/Emulation/Core/Impl/GameSerializer.cs
+++ b/Source/Roton/Emulation/Core/Impl/GameSerializer.cs
@@ -124,9 +124,9 @@ public abstract class GameSerializer(Lazy<IMemory> memory, Lazy<IHeap> heap) : I
                 // check to see if the code needs to be stored
                 if (code != null)
                 {
-                    if (savedCode.ContainsKey(actor.Pointer))
+                    if (savedCode.TryGetValue(actor.Pointer, out var value))
                     {
-                        actor.Length = -savedCode[actor.Pointer];
+                        actor.Length = -value;
                     }
                     else
                     {

--- a/Source/Roton/Emulation/Core/Impl/Keyboard.cs
+++ b/Source/Roton/Emulation/Core/Impl/Keyboard.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Roton.Emulation.Core.Impl;

--- a/Source/Roton/Emulation/Core/Impl/Parser.cs
+++ b/Source/Roton/Emulation/Core/Impl/Parser.cs
@@ -102,17 +102,20 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
 
     public string ReadLine(int index, IExecutable instructionSource)
     {
-        var sb = StringBuilderPool.Rent();
+        // The original ZZT engine used a string[50] Pascal buffer for OOP line reads.
+        // 256 chars is generous headroom while remaining safe for stack allocation (~512 bytes).
+
+        var buffer = (stackalloc char[256]);
+        var length = 0;
         ReadByte(index, instructionSource);
         while (Engine.State.OopByte != 0x00 && Engine.State.OopByte != 0x0D)
         {
-            sb.Append(Engine.State.OopByte.ToChar());
+            if (length < buffer.Length)
+                buffer[length++] = Engine.State.OopByte.ToChar();
             ReadByte(index, instructionSource);
         }
 
-        var result = sb.ToString();
-        StringBuilderPool.Return(sb);
-        return result;
+        return buffer.Slice(0, length).ToString();
     }
 
     public int ReadNumber(int index, IExecutable instructionSource)
@@ -151,7 +154,10 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
 
     public string ReadWord(int index, IExecutable instructionSource)
     {
-        var sb = StringBuilderPool.Rent();
+        // Words are delimited by spaces and non-alphanumeric characters, so they are always short.
+        // 256 chars matches ReadLine and is well above any real-world OOP word length.
+        var buffer = (stackalloc char[256]);
+        var length = 0;
 
         while (true)
         {
@@ -169,7 +175,8 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
         {
             while (oopByte is >= 0x41 and <= 0x5A or >= 0x30 and <= 0x39 or 0x3A or 0x5F)
             {
-                sb.Append(oopByte.ToChar());
+                if (length < buffer.Length)
+                    buffer[length++] = oopByte.ToChar();
                 ReadByte(index, instructionSource);
                 Engine.State.OopByte = Engine.State.OopByte.ToUpperCase();
                 oopByte = Engine.State.OopByte;
@@ -181,9 +188,7 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
             instructionSource.Instruction--;
         }
 
-        Engine.State.OopWord = sb.ToString();
-        StringBuilderPool.Return(sb);
-
+        Engine.State.OopWord = buffer.Slice(0, length).ToString();
         return Engine.State.OopWord;
     }
 

--- a/Source/Roton/Emulation/Core/Impl/Parser.cs
+++ b/Source/Roton/Emulation/Core/Impl/Parser.cs
@@ -117,8 +117,8 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
 
     public int ReadNumber(int index, IExecutable instructionSource)
     {
-        var sb = StringBuilderPool.Rent();
         var success = false;
+        var resultInt = 0;
 
         while (ReadByte(index, instructionSource) == 0x20)
         {
@@ -128,7 +128,7 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
         while (Engine.State.OopByte is >= 0x30 and <= 0x39)
         {
             success = true;
-            sb.Append(Engine.State.OopByte.ToChar());
+            resultInt = resultInt * 10 + (Engine.State.OopByte - 0x30);
             ReadByte(index, instructionSource);
         }
 
@@ -143,11 +143,9 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
         }
         else
         {
-            int.TryParse(sb.ToString(), out var resultInt);
             Engine.State.OopNumber = resultInt;
         }
 
-        StringBuilderPool.Return(sb);
         return Engine.State.OopNumber;
     }
 
@@ -165,7 +163,7 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
         }
 
         Engine.State.OopByte = Engine.State.OopByte.ToUpperCase();
-        var oopByte = Engine.State.OopByte; 
+        var oopByte = Engine.State.OopByte;
 
         if (oopByte is not (>= 0x30 and <= 0x39))
         {

--- a/Source/Roton/Emulation/Core/Impl/Parser.cs
+++ b/Source/Roton/Emulation/Core/Impl/Parser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using Roton.Emulation.Data;
 using Roton.Emulation.Data.Impl;
 using Roton.Emulation.Infrastructure;

--- a/Source/Roton/Emulation/Core/Impl/Parser.cs
+++ b/Source/Roton/Emulation/Core/Impl/Parser.cs
@@ -21,7 +21,11 @@ public sealed class Parser(Lazy<IEngine> engine) : IParser
     public int Search(int index, string term)
     {
         var result = -1;
-        var termBytes = term.ToBytes();
+        if (string.IsNullOrEmpty(term))
+            return result;
+
+        var termBytes = term.Length <= 256 ? stackalloc byte[term.Length] : new byte[term.Length];
+        term.ToBytes(termBytes);
         var actor = Engine.Actors[index];
         var offs = new Executable();
         

--- a/Source/Roton/Emulation/Core/Impl/ScrollFormatter.cs
+++ b/Source/Roton/Emulation/Core/Impl/ScrollFormatter.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using Roton.Emulation.Data.Impl;
 using Roton.Infrastructure.Impl;
 

--- a/Source/Roton/Emulation/Core/Impl/SoundBufferList.cs
+++ b/Source/Roton/Emulation/Core/Impl/SoundBufferList.cs
@@ -75,4 +75,7 @@ public sealed class SoundBufferList : FixedList<int>, ISoundBufferList
     {
         Memory.Write8(_offset, 0);
     }
+
+    protected override bool EqualsItem(int index, int value) => 
+        GetItem(index) == value;
 }

--- a/Source/Roton/Emulation/Data/IExits.cs
+++ b/Source/Roton/Emulation/Data/IExits.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Roton.Emulation.Data;
 
 public interface IExits

--- a/Source/Roton/Emulation/Data/IObjectPool.cs
+++ b/Source/Roton/Emulation/Data/IObjectPool.cs
@@ -1,0 +1,7 @@
+namespace Roton.Emulation.Data;
+
+public interface IObjectPool<T>
+{
+    T Rent();
+    void Return(T obj);
+}

--- a/Source/Roton/Emulation/Data/IOopContext.cs
+++ b/Source/Roton/Emulation/Data/IOopContext.cs
@@ -11,6 +11,7 @@ public interface IOopContext : IExecutable, ISearchContext
     bool Died { get; set; }
     bool Executed { get; set; }
     bool Finished { get; set; }
+    IExecutable InstructionSource { get; set; }
     bool Moved { get; set; }
     string Name { get; set; }
     bool NextLine { get; set; }
@@ -18,6 +19,6 @@ public interface IOopContext : IExecutable, ISearchContext
     bool Repeat { get; set; }
     bool Resume { get; set; }
     int Command { get; set; }
-    int Index { get; }
+    int Index { get; set; }
     bool HasMessage { get; }
 }

--- a/Source/Roton/Emulation/Data/IOopContext.cs
+++ b/Source/Roton/Emulation/Data/IOopContext.cs
@@ -19,4 +19,5 @@ public interface IOopContext : IExecutable, ISearchContext
     bool Resume { get; set; }
     int Command { get; set; }
     int Index { get; }
+    bool HasMessage { get; }
 }

--- a/Source/Roton/Emulation/Data/IOopContextPool.cs
+++ b/Source/Roton/Emulation/Data/IOopContextPool.cs
@@ -1,0 +1,5 @@
+namespace Roton.Emulation.Data;
+
+public interface IOopContextPool : IObjectPool<IOopContext>
+{
+}

--- a/Source/Roton/Emulation/Data/Impl/ActorExtensions.cs
+++ b/Source/Roton/Emulation/Data/Impl/ActorExtensions.cs
@@ -29,11 +29,12 @@ public static class ActorExtensions
 
     public static void ModifyCodeAsString(this IActor self, string value)
     {
-        self.Code ??= [];
-        var code = self.Code;
-        var newCode = value.ToBytes();
-        Array.Resize(ref code, newCode.Length);
-        Buffer.BlockCopy(newCode, 0, code, 0, newCode.Length);
+        var length = value?.Length ?? 0;
+        if (self.Code == null || self.Code.Length != length)
+        {
+            self.Code = new byte[length];
+        }
+        value.ToBytes(self.Code);
     }
 
     public static void SetCodeAsString(this IActor self, string value)

--- a/Source/Roton/Emulation/Data/Impl/ByteString.cs
+++ b/Source/Roton/Emulation/Data/Impl/ByteString.cs
@@ -11,15 +11,15 @@ public sealed class ByteString : FixedList<int>
         _offset = offset;
     }
 
-    public override int Count => _memory.Read8(_offset);
+    public override int Count =>
+        _memory.Read8(_offset);
 
-    protected override int GetItem(int index)
-    {
-        return _memory.Read8(_offset + index + 1);
-    }
+    protected override int GetItem(int index) =>
+        _memory.Read8(_offset + index + 1);
 
-    protected override void SetItem(int index, int value)
-    {
+    protected override void SetItem(int index, int value) =>
         _memory.Write8(_offset + index + 1, value);
-    }
+
+    protected override bool EqualsItem(int index, int value) =>
+        GetItem(index) == value;
 }

--- a/Source/Roton/Emulation/Data/Impl/FixedList.cs
+++ b/Source/Roton/Emulation/Data/Impl/FixedList.cs
@@ -18,7 +18,11 @@ public abstract class FixedList<T> : IList<T>, IReadOnlyList<T>
 
     public virtual bool Contains(T item)
     {
-        return IndexOf(item) >= 0;
+        for (var i = 0; i < Count; i++)
+            if (EqualsItem(i, item))
+                return true;
+
+        return false;
     }
 
     public virtual void CopyTo(T[] array, int arrayIndex)
@@ -74,4 +78,7 @@ public abstract class FixedList<T> : IList<T>, IReadOnlyList<T>
     protected virtual void SetItem(int index, T value)
     {
     }
+
+    protected virtual bool EqualsItem(int index, T value) => 
+        GetItem(index).GetHashCode() == value.GetHashCode();
 }

--- a/Source/Roton/Emulation/Data/Impl/FixedList.cs
+++ b/Source/Roton/Emulation/Data/Impl/FixedList.cs
@@ -41,10 +41,15 @@ public abstract class FixedList<T> : IList<T>, IReadOnlyList<T>
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return new LinearEnumerator<T>(GetItem, Count);
+        return GetEnumerator();
     }
 
-    public IEnumerator<T> GetEnumerator()
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public LinearEnumerator<T> GetEnumerator()
     {
         return new LinearEnumerator<T>(GetItem, Count);
     }

--- a/Source/Roton/Emulation/Data/Impl/FixedStringList.cs
+++ b/Source/Roton/Emulation/Data/Impl/FixedStringList.cs
@@ -1,4 +1,7 @@
-﻿namespace Roton.Emulation.Data.Impl;
+﻿using System;
+using Roton.Emulation.Infrastructure;
+
+namespace Roton.Emulation.Data.Impl;
 
 public abstract class FixedStringList(IMemory memory, int offset) : FixedList<string>
 {
@@ -10,13 +13,25 @@ public abstract class FixedStringList(IMemory memory, int offset) : FixedList<st
             this[i] = string.Empty;
     }
 
-    protected override string GetItem(int index)
+    public override bool Contains(string item)
     {
-        return memory.ReadString(offset + index * ItemLength);
+        for (var i = 0; i < Count; i++)
+            if (EqualsItem(i, item))
+                return true;
+
+        return false;
     }
 
-    protected override void SetItem(int index, string value)
-    {
+    protected override string GetItem(int index) => 
+        memory.ReadString(offset + index * ItemLength);
+
+    private ReadOnlySpan<byte> GetItemSpan(int index) =>
+        memory.ReadStringSpan(offset + index * ItemLength);
+
+    protected override void SetItem(int index, string value) => 
         memory.WriteString(offset + index * ItemLength, value);
-    }
+
+    protected override bool EqualsItem(int index, string value) => 
+        Cp437.CharsEqualBytes(value, GetItemSpan(index));
+
 }

--- a/Source/Roton/Emulation/Data/Impl/Flags.cs
+++ b/Source/Roton/Emulation/Data/Impl/Flags.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using Roton.Emulation.Infrastructure;
 
 namespace Roton.Emulation.Data.Impl;
 
@@ -8,7 +10,7 @@ public abstract class Flags(IMemory memory, int offset) : FixedList<string>, IFl
     {
         if (Contains(item))
             return;
-        
+
         var count = Count;
         for (var i = 0; i < count; i++)
         {
@@ -28,17 +30,6 @@ public abstract class Flags(IMemory memory, int offset) : FixedList<string>, IFl
         }
     }
 
-    public override bool Contains(string item)
-    {
-        var count = Count;
-        for (var i = 0; i < count; i++)
-        {
-            if (GetItem(i) == item)
-                return true;
-        }
-        return false;
-    }
-
     public override bool Remove(string item)
     {
         var count = Count;
@@ -50,6 +41,7 @@ public abstract class Flags(IMemory memory, int offset) : FixedList<string>, IFl
             SetItem(i, string.Empty);
             return true;
         }
+
         return false;
     }
 
@@ -59,7 +51,7 @@ public abstract class Flags(IMemory memory, int offset) : FixedList<string>, IFl
         {
             foreach (var flag in this.Select(f => f.ToUpperInvariant()))
             {
-                if (flag.Length > 0 && flag.StartsWith("Z"))
+                if (flag.Length > 0 && flag[0] == 'Z')
                 {
                     return flag.Substring(1);
                 }
@@ -69,13 +61,15 @@ public abstract class Flags(IMemory memory, int offset) : FixedList<string>, IFl
         }
     }
 
-    protected override string GetItem(int index)
-    {
-        return memory.ReadString(offset + index*21);
-    }
+    protected override string GetItem(int index) => 
+        memory.ReadString(offset + index * 21);
 
-    protected override void SetItem(int index, string value)
-    {
-        memory.WriteString(offset + index*21, value);
-    }
+    private ReadOnlySpan<byte> GetItemSpan(int index) =>
+        memory.ReadStringSpan(offset + index * 21);
+
+    protected override void SetItem(int index, string value) => 
+        memory.WriteString(offset + index * 21, value);
+    
+    protected override bool EqualsItem(int index, string value) => 
+        Cp437.CharsEqualBytes(value, GetItemSpan(index));
 }

--- a/Source/Roton/Emulation/Data/Impl/HighScoreList.cs
+++ b/Source/Roton/Emulation/Data/Impl/HighScoreList.cs
@@ -17,7 +17,6 @@ public sealed class HighScoreList : IHighScoreList
             .. Enumerable
                 .Range(0, count)
                 .Select(_ => new HighScore { Name = string.Empty, Score = -1 })
-                .Cast<IHighScore>()
         ];
     }
         

--- a/Source/Roton/Emulation/Data/Impl/HighScoreListFactory.cs
+++ b/Source/Roton/Emulation/Data/Impl/HighScoreListFactory.cs
@@ -46,11 +46,10 @@ public sealed class HighScoreListFactory(Lazy<IEngine> engine, Lazy<IFacts> fact
         using var writer = new BinaryWriter(stream);
         foreach (var hs in highScoreList)
         {
-            var nameLength = unchecked((byte) hs.Name.Length);
+            var nameLength = unchecked((byte) (hs.Name?.Length ?? 0));
             var nameBuffer = new byte[Facts.HighScoreNameLength];
-            var name = hs.Name.ToBytes();
+            hs.Name.ToBytes(nameBuffer.AsSpan(0, Math.Min(nameLength, nameBuffer.Length)));
             var score = unchecked((short) hs.Score);
-            Buffer.BlockCopy(name, 0, nameBuffer, 0, Math.Min(nameLength, nameBuffer.Length));
             writer.Write(nameLength);
             writer.Write(nameBuffer);
             writer.Write(score);

--- a/Source/Roton/Emulation/Data/Impl/LinearEnumerator.cs
+++ b/Source/Roton/Emulation/Data/Impl/LinearEnumerator.cs
@@ -4,38 +4,26 @@ using System.Collections.Generic;
 
 namespace Roton.Emulation.Data.Impl;
 
-public sealed class LinearEnumerator<T> : IEnumerator<T>
+public struct LinearEnumerator<T>(Func<int, T> getter, int count) : IEnumerator<T>
 {
-    internal LinearEnumerator(Func<int, T> getter, int count)
-    {
-        Count = count;
-        Getter = getter;
-        Reset();
-    }
-
-    private int Count { get; }
-
-    private Func<int, T> Getter { get; set; }
-
-    private int Index { get; set; }
+    private int _index = -1;
 
     public void Dispose()
     {
-        Getter = null;
     }
 
-    object IEnumerator.Current => Getter(Index);
+    object IEnumerator.Current => Current;
 
     public bool MoveNext()
     {
-        Index++;
-        return Index < Count;
+        _index++;
+        return _index < count;
     }
 
     public void Reset()
     {
-        Index = -1;
+        _index = -1;
     }
 
-    public T Current => Getter(Index);
+    public T Current => getter(_index);
 }

--- a/Source/Roton/Emulation/Data/Impl/MemoryExtensions.cs
+++ b/Source/Roton/Emulation/Data/Impl/MemoryExtensions.cs
@@ -169,11 +169,23 @@ public static class MemoryExtensions
             unchecked
             {
                 var span = memory.Data;
-                var encodedString = value.ToBytes();
-                var length = encodedString.Length & 0xFF;
-                span[offset++] = (byte) length;
-                for (var i = 0; i < length; i++)
-                    span[offset++] = encodedString[i];
+                var length = (value?.Length ?? 0) & 0xFF;
+                span[offset & 0xFFFF] = (byte) length;
+                if (length > 0)
+                {
+                    var destination = span.Slice((offset + 1) & 0xFFFF);
+                    // Handle wrap-around if necessary
+                    if (destination.Length >= length)
+                    {
+                        value.ToBytes(destination.Slice(0, length));
+                    }
+                    else
+                    {
+                        // Fallback for wrap-around
+                        for (var i = 0; i < length; i++)
+                            span[(offset + 1 + i) & 0xFFFF] = Cp437.CharToByte(value![i]);
+                    }
+                }
             }
         }
     }

--- a/Source/Roton/Emulation/Data/Impl/MemoryExtensions.cs
+++ b/Source/Roton/Emulation/Data/Impl/MemoryExtensions.cs
@@ -74,6 +74,25 @@ public static class MemoryExtensions
         }
 
         [DebuggerStepThrough]
+        internal ReadOnlySpan<byte> ReadStringSpan(int offset = 0)
+        {
+            unchecked
+            {
+                var span = memory.Data;
+                var length = span[offset & 0xFFFF];
+
+                if (offset + length <= memory.Data.Length) 
+                    return span.Slice(offset + 1, length);
+
+                var result = new byte[length];
+                for (var i = 0; i < length; i++)
+                    result[i] = span[++offset & 0xFFFF];
+                return result;
+
+            }
+        }
+
+        [DebuggerStepThrough]
         internal void Write(int offset, ReadOnlySpan<byte> data)
         {
             unchecked

--- a/Source/Roton/Emulation/Data/Impl/ObjectPool.cs
+++ b/Source/Roton/Emulation/Data/Impl/ObjectPool.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Roton.Emulation.Data.Impl;
+
+public abstract class ObjectPool<T>(Func<T> factory, Action<T> reset)
+{
+    private readonly ConcurrentStack<T> _pool = new();
+
+    public T Rent() =>
+        _pool.TryPop(out var item) ? item : factory();
+
+    public void Return(T item)
+    {
+        reset(item);
+        _pool.Push(item);
+    }
+}

--- a/Source/Roton/Emulation/Data/Impl/OopContext.cs
+++ b/Source/Roton/Emulation/Data/Impl/OopContext.cs
@@ -5,37 +5,25 @@ namespace Roton.Emulation.Data.Impl;
 
 public sealed class OopContext : IOopContext
 {
-    private readonly int _index;
-        
-    private readonly IExecutable _instructionSource;
     private readonly IEngine _engine;
-    private ITile _deathTile;
-    private List<string> _message;
 
     internal OopContext(
-        int index,
-        IExecutable instructionSource,
-        string name,
         IEngine engine)
     {
-        _instructionSource = instructionSource;
         _engine = engine;
-        _index = index;
-        Index = index;
-        Name = name;
     }
 
     public int Instruction
     {
-        get => _instructionSource.Instruction;
-        set => _instructionSource.Instruction = value;
+        get => InstructionSource.Instruction;
+        set => InstructionSource.Instruction = value;
     }
 
-    public IActor Actor => _engine.Actors[_index];
+    public IActor Actor => _engine.Actors[Index];
 
     public int CommandsExecuted { get; set; }
 
-    public ITile DeathTile => _deathTile ??= new Tile(0, 0);
+    public ITile DeathTile { get; } = new Tile(0, 0);
 
     public bool Died { get; set; }
 
@@ -43,11 +31,13 @@ public sealed class OopContext : IOopContext
 
     public bool Finished { get; set; }
 
+    public IExecutable InstructionSource { get; set; }
+
     public int Index { get; set; }
 
-    public bool HasMessage => _message is { Count: > 0 };
+    public bool HasMessage => Message.Count > 0;
 
-    public IList<string> Message => _message ??= [];
+    public IList<string> Message { get; } = new List<string>();
 
     public bool Moved { get; set; }
 

--- a/Source/Roton/Emulation/Data/Impl/OopContext.cs
+++ b/Source/Roton/Emulation/Data/Impl/OopContext.cs
@@ -9,6 +9,8 @@ public sealed class OopContext : IOopContext
         
     private readonly IExecutable _instructionSource;
     private readonly IEngine _engine;
+    private ITile _deathTile;
+    private List<string> _message;
 
     internal OopContext(
         int index,
@@ -21,8 +23,6 @@ public sealed class OopContext : IOopContext
         _index = index;
         Index = index;
         Name = name;
-        DeathTile = new Tile(0, 0);
-        Message = new List<string>();
     }
 
     public int Instruction
@@ -35,7 +35,7 @@ public sealed class OopContext : IOopContext
 
     public int CommandsExecuted { get; set; }
 
-    public ITile DeathTile { get; }
+    public ITile DeathTile => _deathTile ??= new Tile(0, 0);
 
     public bool Died { get; set; }
 
@@ -45,7 +45,9 @@ public sealed class OopContext : IOopContext
 
     public int Index { get; set; }
 
-    public IList<string> Message { get; }
+    public bool HasMessage => _message is { Count: > 0 };
+
+    public IList<string> Message => _message ??= [];
 
     public bool Moved { get; set; }
 

--- a/Source/Roton/Emulation/Data/Impl/OopContext.cs
+++ b/Source/Roton/Emulation/Data/Impl/OopContext.cs
@@ -63,7 +63,5 @@ public sealed class OopContext : IOopContext
 
     public int SearchOffset { get; set; }
 
-    public string SearchTarget { get; set; }
-        
     public int Command { get; set; }
 }

--- a/Source/Roton/Emulation/Data/Impl/OopContextPool.cs
+++ b/Source/Roton/Emulation/Data/Impl/OopContextPool.cs
@@ -1,0 +1,29 @@
+using Roton.Emulation.Core;
+using Roton.Infrastructure.Impl;
+
+namespace Roton.Emulation.Data.Impl;
+
+[Context(Context.Original)]
+[Context(Context.Super)]
+public sealed class OopContextPool(IEngine engine)
+    : ObjectPool<IOopContext>(() => new OopContext(engine), Reset), IOopContextPool
+{
+    private static void Reset(IOopContext obj)
+    {
+        obj.InstructionSource = null;
+        obj.CommandsExecuted = 0;
+        obj.Moved = false;
+        obj.Repeat = false;
+        obj.Died = false;
+        obj.Finished = false;
+        obj.Executed = false;
+        obj.NextLine = false;
+        obj.PreviousInstruction = 0;
+        obj.Resume = false;
+        obj.SearchIndex = 0;
+        obj.SearchOffset = 0;
+        obj.Command = 0;
+        obj.Message.Clear();
+        obj.DeathTile?.SetTo(0, 0);
+    }
+}

--- a/Source/Roton/Emulation/Data/Impl/PackedBoard.cs
+++ b/Source/Roton/Emulation/Data/Impl/PackedBoard.cs
@@ -19,10 +19,11 @@ public sealed class PackedBoard : IPackedBoard
         {
             if (Data.Length >= 260)
             {
-                int nameLength = Data[0];
-                var nameData = new byte[nameLength];
-                Buffer.BlockCopy(Data, 1, nameData, 0, nameLength);
-                return nameData.ToStringValue();
+                var nameLength = Data[0];
+                if (nameLength == 0) return string.Empty;
+                Span<char> chars = stackalloc char[nameLength];
+                Cp437.BytesToChars(Data.AsSpan(1, nameLength), chars);
+                return new string(chars.ToArray());
             }
             return string.Empty;
         }
@@ -30,10 +31,12 @@ public sealed class PackedBoard : IPackedBoard
         {
             if (Data.Length >= 260)
             {
-                var nameData = value.ToBytes();
-                var nameLength = (byte) (nameData.Length & 0xFF);
+                var nameLength = (byte)((value?.Length ?? 0) & 0xFF);
                 Data[0] = nameLength;
-                Buffer.BlockCopy(nameData, 0, Data, 1, nameLength);
+                if (nameLength > 0)
+                {
+                    value.ToBytes(Data.AsSpan(1, nameLength));
+                }
             }
         }
     }

--- a/Source/Roton/Emulation/Data/Impl/TextContent.cs
+++ b/Source/Roton/Emulation/Data/Impl/TextContent.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Roton.Emulation.Data.Impl;
 

--- a/Source/Roton/Emulation/Directions/IDirectionList.cs
+++ b/Source/Roton/Emulation/Directions/IDirectionList.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Roton.Emulation.Directions;
 
 public interface IDirectionList
 {
-    IDirection Get(string name);
+    IDirection Get(ReadOnlySpan<char> name);
 }

--- a/Source/Roton/Emulation/Directions/Impl/DirectionList.cs
+++ b/Source/Roton/Emulation/Directions/Impl/DirectionList.cs
@@ -30,8 +30,8 @@ public sealed class DirectionList : IDirectionList
 
     public IDirection Get(string name)
     {
-        return _directions.Value.ContainsKey(name)
-            ? _directions.Value[name]
+        return _directions.Value.TryGetValue(name, out var value)
+            ? value
             : null;
     }
 }

--- a/Source/Roton/Emulation/Directions/Impl/DirectionList.cs
+++ b/Source/Roton/Emulation/Directions/Impl/DirectionList.cs
@@ -11,6 +11,7 @@ namespace Roton.Emulation.Directions.Impl;
 public sealed class DirectionList : IDirectionList
 {
     private readonly Lazy<IDictionary<string, IDirection>> _directions;
+    private IDictionary<string, IDirection> Directions => _directions.Value;
 
     public DirectionList(Lazy<IContextMetadataService> contextMetadataService,
         Lazy<IEnumerable<IDirection>> directions)
@@ -18,6 +19,7 @@ public sealed class DirectionList : IDirectionList
         _directions = new Lazy<IDictionary<string, IDirection>>(() =>
         {
             var result = new Dictionary<string, IDirection>();
+
             foreach (var direction in directions.Value)
             {
                 foreach (var attribute in contextMetadataService.Value.GetMetadata(direction))
@@ -28,10 +30,14 @@ public sealed class DirectionList : IDirectionList
         });
     }
 
-    public IDirection Get(string name)
+    public IDirection Get(ReadOnlySpan<char> name)
     {
-        return _directions.Value.TryGetValue(name, out var value)
-            ? value
-            : null;
+        foreach (var entry in Directions)
+        {
+            if (name.Equals(entry.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        return null;
     }
 }

--- a/Source/Roton/Emulation/Draws/Impl/DrawList.cs
+++ b/Source/Roton/Emulation/Draws/Impl/DrawList.cs
@@ -11,8 +11,10 @@ namespace Roton.Emulation.Draws.Impl;
 public sealed class DrawList : IDrawList
 {
     private readonly Lazy<IDictionary<int, IDraw>> _draws;
+    private IDictionary<int, IDraw> Draws => _draws.Value;
 
-    public DrawList(Lazy<IContextMetadataService> contextMetadataService, Lazy<IEnumerable<IDraw>> draws)
+    public DrawList(Lazy<IContextMetadataService> contextMetadataService,
+        Lazy<IEnumerable<IDraw>> draws)
     {
         _draws = new Lazy<IDictionary<int, IDraw>>(() =>
         {
@@ -29,8 +31,8 @@ public sealed class DrawList : IDrawList
 
     public IDraw Get(int index)
     {
-        return _draws.Value.TryGetValue(index, out var value) 
-            ? value 
-            : _draws.Value[-1];
+        return Draws.TryGetValue(index, out var value)
+            ? value
+            : Draws[-1];
     }
 }

--- a/Source/Roton/Emulation/Draws/Impl/DrawList.cs
+++ b/Source/Roton/Emulation/Draws/Impl/DrawList.cs
@@ -29,8 +29,8 @@ public sealed class DrawList : IDrawList
 
     public IDraw Get(int index)
     {
-        return _draws.Value.ContainsKey(index) 
-            ? _draws.Value[index] 
+        return _draws.Value.TryGetValue(index, out var value) 
+            ? value 
             : _draws.Value[-1];
     }
 }

--- a/Source/Roton/Emulation/Infrastructure/Cp437.cs
+++ b/Source/Roton/Emulation/Infrastructure/Cp437.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace Roton.Emulation.Infrastructure;
+
+/// <summary>
+/// Implements a Code Page 437 character map.
+/// </summary>
+[PublicAPI]
+public static class Cp437
+{
+    private static readonly char[] ByteToCharArray =
+    [
+        '\u0000', '\u263A', '\u263B', '\u2665', '\u2666', '\u2663', '\u2660', '\u2022',
+        '\u25D8', '\u25CB', '\u25D9', '\u2642', '\u2640', '\u266A', '\u266B', '\u263C',
+        '\u25BA', '\u25C4', '\u2195', '\u203C', '\u00B6', '\u00A7', '\u25AC', '\u21A8',
+        '\u2191', '\u2193', '\u2192', '\u2190', '\u221F', '\u2194', '\u25B2', '\u25BC',
+        '\u0020', '\u0021', '\u0022', '\u0023', '\u0024', '\u0025', '\u0026', '\u0027',
+        '\u0028', '\u0029', '\u002A', '\u002B', '\u002C', '\u002D', '\u002E', '\u002F',
+        '\u0030', '\u0031', '\u0032', '\u0033', '\u0034', '\u0035', '\u0036', '\u0037',
+        '\u0038', '\u0039', '\u003A', '\u003B', '\u003C', '\u003D', '\u003E', '\u003F',
+        '\u0040', '\u0041', '\u0042', '\u0043', '\u0044', '\u0045', '\u0046', '\u0047',
+        '\u0048', '\u0049', '\u004A', '\u004B', '\u004C', '\u004D', '\u004E', '\u004F',
+        '\u0050', '\u0051', '\u0052', '\u0053', '\u0054', '\u0055', '\u0056', '\u0057',
+        '\u0058', '\u0059', '\u005A', '\u005B', '\u005C', '\u005D', '\u005E', '\u005F',
+        '\u0060', '\u0061', '\u0062', '\u0063', '\u0064', '\u0065', '\u0066', '\u0067',
+        '\u0068', '\u0069', '\u006A', '\u006B', '\u006C', '\u006D', '\u006E', '\u006F',
+        '\u0070', '\u0071', '\u0072', '\u0073', '\u0074', '\u0075', '\u0076', '\u0077',
+        '\u0078', '\u0079', '\u007A', '\u007B', '\u007C', '\u007D', '\u007E', '\u2302',
+        '\u00C7', '\u00FC', '\u00E9', '\u00E2', '\u00E4', '\u00E0', '\u00E5', '\u00E7',
+        '\u00EA', '\u00EB', '\u00E8', '\u00EF', '\u00EE', '\u00EC', '\u00C4', '\u00C5',
+        '\u00C9', '\u00E6', '\u00C6', '\u00F4', '\u00F6', '\u00F2', '\u00FB', '\u00F9',
+        '\u00FF', '\u00D6', '\u00DC', '\u00A2', '\u00A3', '\u00A5', '\u20A7', '\u0192',
+        '\u00E1', '\u00ED', '\u00F3', '\u00FA', '\u00F1', '\u00D1', '\u00AA', '\u00BA',
+        '\u00BF', '\u2310', '\u00AC', '\u00BD', '\u00BC', '\u00A1', '\u00AB', '\u00BB',
+        '\u2591', '\u2592', '\u2593', '\u2502', '\u2524', '\u2561', '\u2562', '\u2556',
+        '\u2555', '\u2563', '\u2551', '\u2557', '\u255D', '\u255C', '\u255B', '\u2510',
+        '\u2514', '\u2534', '\u252C', '\u251C', '\u2500', '\u253C', '\u255E', '\u255F',
+        '\u255A', '\u2554', '\u2569', '\u2566', '\u2560', '\u2550', '\u256C', '\u2567',
+        '\u2568', '\u2564', '\u2565', '\u2559', '\u2558', '\u2552', '\u2553', '\u256B',
+        '\u256A', '\u2518', '\u250C', '\u2588', '\u2584', '\u258C', '\u2590', '\u2580',
+        '\u03B1', '\u00DF', '\u0393', '\u03C0', '\u03A3', '\u03C3', '\u00B5', '\u03C4',
+        '\u03A6', '\u0398', '\u03A9', '\u03B4', '\u221E', '\u03C6', '\u03B5', '\u2229',
+        '\u2261', '\u00B1', '\u2265', '\u2264', '\u2320', '\u2321', '\u00F7', '\u2248',
+        '\u00B0', '\u2219', '\u00B7', '\u221A', '\u207F', '\u00B2', '\u25A0', '\u00A0'
+    ];
+
+    private static readonly Dictionary<char, byte> CharToByteDict = ByteToCharArray
+        .Select((e, i) => new KeyValuePair<char, byte>(e, (byte)i))
+        .ToDictionary(x => x.Key, x => x.Value);
+
+    /// <summary>
+    /// Converts from byte to char, preserving control characters.
+    /// </summary>
+    public static char ByteToChar(byte value) =>
+        value < 0x20 ? (char)value : ByteToUnicode(value);
+
+    /// <summary>
+    /// Converts from byte to char, preserving graphics.
+    /// </summary>
+    public static char ByteToUnicode(byte value) =>
+        ByteToCharArray[value];
+
+    /// <summary>
+    /// Converts from char to byte, preserving control characters.
+    /// </summary>
+    public static byte CharToByte(char value) =>
+        value < 0x20 ? unchecked((byte)value) : UnicodeToByte(value);
+
+    /// <summary>
+    /// Converts from char to byte, preserving graphics.
+    /// </summary>
+    public static byte UnicodeToByte(char value) =>
+        CharToByteDict.TryGetValue(value, out var result) ? result : (byte)0x20;
+
+    /// <summary>
+    /// Converts from bytes to chars, preserving control characters.
+    /// </summary>
+    public static int BytesToChars(ReadOnlySpan<byte> bytes, Span<char> chars)
+    {
+        var max = Math.Min(bytes.Length, chars.Length);
+
+        for (var i = 0; i < max; i++)
+            chars[i] = ByteToChar(bytes[i]);
+
+        return max;
+    }
+
+    /// <summary>
+    /// Converts from bytes to chars, preserving graphics.
+    /// </summary>
+    public static int BytesToUnicode(ReadOnlySpan<byte> bytes, Span<char> chars)
+    {
+        var max = Math.Min(bytes.Length, chars.Length);
+
+        for (var i = 0; i < max; i++)
+            chars[i] = ByteToUnicode(bytes[i]);
+
+        return max;
+    }
+
+    /// <summary>
+    /// Converts from chars to bytes, preserving control characters.
+    /// </summary>
+    public static int CharsToBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
+    {
+        var max = Math.Min(bytes.Length, chars.Length);
+
+        for (var i = 0; i < max; i++)
+            bytes[i] = CharToByte(chars[i]);
+
+        return max;
+    }
+
+    /// <summary>
+    /// Converts from chars to bytes, preserving graphics.
+    /// </summary>
+    public static int UnicodeToBytes(ReadOnlySpan<char> chars, Span<byte> bytes)
+    {
+        var max = Math.Min(bytes.Length, chars.Length);
+
+        for (var i = 0; i < max; i++)
+            bytes[i] = UnicodeToByte(chars[i]);
+
+        return max;
+    }
+
+    public static bool CharsEqualBytes(ReadOnlySpan<char> chars, ReadOnlySpan<byte> bytes)
+    {
+        if (chars.IsEmpty && bytes.IsEmpty)
+            return true;
+
+        if (chars.Length != bytes.Length)
+            return false;
+
+        for (var i = 0; i < chars.Length; i++)
+            if (ByteToChar(bytes[i]) != chars[i])
+                return false;
+
+        return true;
+    }
+}

--- a/Source/Roton/Emulation/Infrastructure/Utility.cs
+++ b/Source/Roton/Emulation/Infrastructure/Utility.cs
@@ -1,16 +1,12 @@
 ﻿using System;
-using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 
 namespace Roton.Emulation.Infrastructure;
 
 internal static class Utility
 {
-    private static readonly Encoding CodePage437 = CodePagesEncodingProvider.Instance.GetEncoding(437);
-
     private static readonly ThreadLocal<byte[]> OneByteArray = new(() => new byte[1]);
     private static readonly ThreadLocal<char[]> OneCharArray = new(() => new char[1]);
     
@@ -44,14 +40,8 @@ internal static class Utility
         /// Convert an integer to a character using code page 437.
         /// </summary>
         [DebuggerStepThrough]
-        public char ToChar()
-        {
-            var bytes = OneByteArray.Value;
-            bytes[0] = unchecked((byte)(a & 0xFF));
-            var chars = OneCharArray.Value;
-            CodePage437.GetChars(bytes, 0, 1, chars, 0);
-            return chars[0];
-        }
+        public char ToChar() => 
+            Cp437.ByteToChar(unchecked((byte)a));
 
         /// <summary>
         /// Get the uppercase representation of an ASCII char stored as an integer.
@@ -70,8 +60,12 @@ internal static class Utility
     /// </summary>
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string ToStringValue(this byte[] value) =>
-        CodePage437.GetString(value);
+    public static string ToStringValue(this byte[] value)
+    {
+        var str = new char[value.Length];
+        Cp437.BytesToChars(value, str);
+        return new string(str);
+    }
 
     /// <summary>
     /// Get the uppercase representation of an input key.
@@ -162,9 +156,14 @@ internal static class Utility
         /// Convert a string to a byte array using code page 437.
         /// </summary>
         [DebuggerStepThrough]
-        public byte[] ToBytes() =>
-            string.IsNullOrEmpty(a)
-                ? []
-                : CodePage437.GetBytes(a);
+        public byte[] ToBytes()
+        {
+            if (string.IsNullOrEmpty(a))
+                return [];
+            
+            var result = new byte[a.Length];
+            Cp437.CharsToBytes(a, result);
+            return result;
+        }
     }
 }

--- a/Source/Roton/Emulation/Infrastructure/Utility.cs
+++ b/Source/Roton/Emulation/Infrastructure/Utility.cs
@@ -40,6 +40,7 @@ internal static class Utility
         /// Convert an integer to a character using code page 437.
         /// </summary>
         [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public char ToChar() => 
             Cp437.ByteToChar(unchecked((byte)a));
 

--- a/Source/Roton/Emulation/Infrastructure/Utility.cs
+++ b/Source/Roton/Emulation/Infrastructure/Utility.cs
@@ -172,5 +172,17 @@ internal static class Utility
 
             return Cp437.CharsToBytes(a, destination);
         }
+
+        /// <summary>
+        /// Convert a byte array to a string using code page 437.
+        /// </summary>
+        [DebuggerStepThrough]
+        public string UpCased()
+        {
+            var str = new char[a.Length];
+            for (var i = 0; i < a.Length; i++)
+                str[i] = unchecked((char)((int)a[i]).ToUpperCase());
+            return new string(str);
+        }
     }
 }

--- a/Source/Roton/Emulation/Infrastructure/Utility.cs
+++ b/Source/Roton/Emulation/Infrastructure/Utility.cs
@@ -97,13 +97,10 @@ internal static class Utility
         /// Compares source string to another string, with the source UpperCased.
         /// </summary>
         [DebuggerStepThrough]
-        public bool CaseInsensitiveEqual(string b)
+        public bool CaseInsensitiveEqual(ReadOnlySpan<char> b)
         {
-            if (a == null != (b == null))
-                return false;
-
             if (a == null)
-                return true;
+                return false;
 
             if (a.Length != b.Length)
                 return false;
@@ -121,16 +118,13 @@ internal static class Utility
         /// Compares source string to another string, with the source UpperCased, and only A-Z.
         /// </summary>
         [DebuggerStepThrough]
-        public bool CaseInsensitiveCharacterEqual(string b)
+        public bool CaseInsensitiveCharacterEqual(ReadOnlySpan<char> b)
         {
             var i = 0;
             var j = 0;
 
-            if (a == null != (b == null))
-                return false;
-
             if (a == null)
-                return true;
+                return false;
 
             while (i < a.Length)
             {

--- a/Source/Roton/Emulation/Infrastructure/Utility.cs
+++ b/Source/Roton/Emulation/Infrastructure/Utility.cs
@@ -165,5 +165,17 @@ internal static class Utility
             Cp437.CharsToBytes(a, result);
             return result;
         }
+
+        /// <summary>
+        /// Convert a string to a byte array using code page 437.
+        /// </summary>
+        [DebuggerStepThrough]
+        public int ToBytes(Span<byte> destination)
+        {
+            if (string.IsNullOrEmpty(a))
+                return 0;
+
+            return Cp437.CharsToBytes(a, destination);
+        }
     }
 }

--- a/Source/Roton/Emulation/Interactions/Impl/EnergizerInteraction.cs
+++ b/Source/Roton/Emulation/Interactions/Impl/EnergizerInteraction.cs
@@ -18,7 +18,7 @@ public sealed class EnergizerInteraction(Lazy<IEngine> engine) : IInteraction
         Engine.RemoveItem(location);
         Engine.World.EnergyCycles = Engine.Facts.EnergyCyclesPerEnergizer;
         Engine.Hud.UpdateStatus();
-        Engine.UpdateBoard(location);
+
         if (Engine.Alerts.EnergizerPickup)
         {
             Engine.Alerts.EnergizerPickup = false;

--- a/Source/Roton/Emulation/Interactions/Impl/InteractionList.cs
+++ b/Source/Roton/Emulation/Interactions/Impl/InteractionList.cs
@@ -29,8 +29,8 @@ public sealed class InteractionList : IInteractionList
 
     public IInteraction Get(int index)
     {
-        return _interactions.Value.ContainsKey(index)
-            ? _interactions.Value[index]
+        return _interactions.Value.TryGetValue(index, out var value)
+            ? value
             : _interactions.Value[-1];
     }
 }

--- a/Source/Roton/Emulation/Items/IItemList.cs
+++ b/Source/Roton/Emulation/Items/IItemList.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Roton.Emulation.Items;
 
 public interface IItemList
 {
-    IItem Get(string name);
+    IItem Get(ReadOnlySpan<char> name);
 }

--- a/Source/Roton/Emulation/Items/Impl/ItemList.cs
+++ b/Source/Roton/Emulation/Items/Impl/ItemList.cs
@@ -29,8 +29,8 @@ public sealed class ItemList : IItemList
 
     public IItem Get(string name)
     {
-        return _items.Value.ContainsKey(name)
-            ? _items.Value[name]
+        return _items.Value.TryGetValue(name, out var value)
+            ? value
             : null;
     }
 }

--- a/Source/Roton/Emulation/Items/Impl/ItemList.cs
+++ b/Source/Roton/Emulation/Items/Impl/ItemList.cs
@@ -11,12 +11,15 @@ namespace Roton.Emulation.Items.Impl;
 public sealed class ItemList : IItemList
 {
     private readonly Lazy<IDictionary<string, IItem>> _items;
+    private IDictionary<string, IItem> Items => _items.Value;
 
-    public ItemList(Lazy<IContextMetadataService> contextMetadataService, Lazy<IEnumerable<IItem>> items)
+    public ItemList(Lazy<IContextMetadataService> contextMetadataService,
+        Lazy<IEnumerable<IItem>> items)
     {
         _items = new Lazy<IDictionary<string, IItem>>(() =>
         {
             var result = new Dictionary<string, IItem>();
+
             foreach (var item in items.Value)
             {
                 foreach (var attribute in contextMetadataService.Value.GetMetadata(item))
@@ -27,10 +30,14 @@ public sealed class ItemList : IItemList
         });
     }
 
-    public IItem Get(string name)
+    public IItem Get(ReadOnlySpan<char> name)
     {
-        return _items.Value.TryGetValue(name, out var value)
-            ? value
-            : null;
+        foreach (var entry in Items)
+        {
+            if (name.Equals(entry.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        return null;
     }
 }

--- a/Source/Roton/Emulation/Original/OriginalFeatures.cs
+++ b/Source/Roton/Emulation/Original/OriginalFeatures.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Roton.Emulation.Core;
 using Roton.Emulation.Data;
 using Roton.Emulation.Data.Impl;

--- a/Source/Roton/Emulation/Original/OriginalHud.cs
+++ b/Source/Roton/Emulation/Original/OriginalHud.cs
@@ -386,7 +386,7 @@ public sealed class OriginalHud : Hud
             
         foreach (var hs in highScoreList)
         {
-            if (index < 0 && hs.Score <= score)
+            if (score > 0 && index < 0 && hs.Score <= score)
             {
                 index = nameIndex;
                 nameList.Add($"{score.ToString(),5}  -- You! --");

--- a/Source/Roton/Emulation/Super/SuperFeatures.cs
+++ b/Source/Roton/Emulation/Super/SuperFeatures.cs
@@ -59,6 +59,8 @@ public sealed class SuperFeatures(Lazy<IEngine> engine) : IFeatures
             Engine.Tiles[location].Id = Engine.ElementList.EmptyId;
         else
             Engine.Tiles[location].CopyFrom(result);
+
+        Engine.UpdateBoard(location);
     }
 
     public string GetWorldName(string baseName) => $"{baseName}.SZT";

--- a/Source/Roton/Emulation/Super/SuperFeatures.cs
+++ b/Source/Roton/Emulation/Super/SuperFeatures.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Roton.Emulation.Core;
 using Roton.Emulation.Data;
 using Roton.Emulation.Data.Impl;

--- a/Source/Roton/Emulation/Super/SuperFeatures.cs
+++ b/Source/Roton/Emulation/Super/SuperFeatures.cs
@@ -130,7 +130,8 @@ public sealed class SuperFeatures(Lazy<IEngine> engine) : IFeatures
 
     public bool CanPutTile(IXyPair location)
     {
-        return true;
+        // do not allow #put on the bottom row
+        return location.Y < Engine.Tiles.Height;
     }
 
     public void ClearForest(IXyPair location)

--- a/Source/Roton/Emulation/Super/SuperHud.cs
+++ b/Source/Roton/Emulation/Super/SuperHud.cs
@@ -425,7 +425,7 @@ public sealed class SuperHud(
 
     public override string EnterHighScore(IHighScoreList highScoreList, int score)
     {
-        if (!highScoreList.Any(hs => hs.Score <= score))
+        if (score <= 0 || !highScoreList.Any(hs => hs.Score <= score))
         {
             return null;
         }

--- a/Source/Roton/Emulation/Targets/ITargetList.cs
+++ b/Source/Roton/Emulation/Targets/ITargetList.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Roton.Emulation.Targets;
 
 public interface ITargetList
 {
-    ITarget Get(string name);
+    ITarget Get(ReadOnlySpan<char> name);
 }

--- a/Source/Roton/Emulation/Targets/Impl/DefaultTarget.cs
+++ b/Source/Roton/Emulation/Targets/Impl/DefaultTarget.cs
@@ -25,10 +25,8 @@ public sealed class DefaultTarget(Lazy<IActors> actors, Lazy<IParser> parser) : 
                 if (firstByte == 0x40)
                 {
                     var name = Parser.ReadWord(context.SearchIndex, instruction);
-                    if (name == term)
-                    {
+                    if (name.Equals(term, StringComparison.OrdinalIgnoreCase))
                         return true;
-                    }
                 }
             }
             context.SearchIndex++;

--- a/Source/Roton/Emulation/Targets/Impl/TargetList.cs
+++ b/Source/Roton/Emulation/Targets/Impl/TargetList.cs
@@ -11,12 +11,15 @@ namespace Roton.Emulation.Targets.Impl;
 public sealed class TargetList : ITargetList
 {
     private readonly Lazy<IDictionary<string, ITarget>> _targets;
+    private IDictionary<string, ITarget> Targets => _targets.Value;
 
-    public TargetList(Lazy<IContextMetadataService> contextMetadataService, Lazy<IEnumerable<ITarget>> targets)
+    public TargetList(Lazy<IContextMetadataService> contextMetadataService,
+        Lazy<IEnumerable<ITarget>> targets)
     {
         _targets = new Lazy<IDictionary<string, ITarget>>(() =>
         {
             var result = new Dictionary<string, ITarget>();
+
             foreach (var target in targets.Value)
             {
                 foreach (var attribute in contextMetadataService.Value.GetMetadata(target))
@@ -26,11 +29,15 @@ public sealed class TargetList : ITargetList
             return result;
         });
     }
-        
-    public ITarget Get(string name)
+
+    public ITarget Get(ReadOnlySpan<char> name)
     {
-        return _targets.Value.TryGetValue(name, out var value)
-            ? value
-            : null;
-    }        
+        foreach (var entry in Targets)
+        {
+            if (name.Equals(entry.Key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        return null;
+    }
 }

--- a/Source/Roton/Infrastructure/Impl/AssemblyResourceService.cs
+++ b/Source/Roton/Infrastructure/Impl/AssemblyResourceService.cs
@@ -18,8 +18,8 @@ public sealed class AssemblyResourceService : IAssemblyResourceService
     {
         var assembly = typeof(T).Assembly;
 
-        if (_cache.ContainsKey(assembly))
-            return _cache[assembly];
+        if (_cache.TryGetValue(assembly, out var of))
+            return of;
             
         var name = $"{assembly.GetName().Name}.Resources.resources.zip";
         using var stream = assembly.GetManifestResourceStream(name);

--- a/Source/Roton/Roton.csproj
+++ b/Source/Roton/Roton.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-        <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.11" />
+        <PackageReference Include="System.Memory" Version="4.6.3" />
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Resources\resources.zip"/>


### PR DESCRIPTION
- LinearEnumerator is a struct enumerator now
- CodePages package is replaced with a leaner Code Page 437 class
- Convert some of the APIs that accept `string` to `Span<char>`
- Fix an issue where Super ZZT could use `#PUT` on the bottom row (no longer possible, replicates original bug)
- Fix restart-on-zap tile clearing behavior in Super ZZT
- Score of 0 or less won't count in the high score table anymore
- More closely replicate label skip behavior in OOP interpreter (no observable difference though)
- Fix a bug that could happen when shooting enemies or breakable walls point-blank
- Fix a bug where breakable tiles that were shot in Super ZZT were not redrawn
- Some other small inconsequential fixes