### PR TITLE
Optimizations, migration away from DotSDL to plain SDL3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Include/DotSDL"]
-	path = Include/DotSDL
-	url = https://github.com/SaxxonPike/DotSDL

--- a/Source/Lyon/App/IWindow.cs
+++ b/Source/Lyon/App/IWindow.cs
@@ -2,7 +2,6 @@
 
 public interface IWindow
 {
-    void SetSize(int width, int height);
     void Start(float updateRate);
     void Close();
 }

--- a/Source/Lyon/App/Impl/FileSystemFactory.cs
+++ b/Source/Lyon/App/Impl/FileSystemFactory.cs
@@ -2,26 +2,18 @@ using Roton;
 using Roton.Emulation.Core;
 using Roton.Emulation.Core.Impl;
 using Roton.Infrastructure;
-using Roton.Infrastructure.Impl;
 
 namespace Lyon.App.Impl;
 
 [Context(Context.Startup)]
-public sealed class FileSystemFactory : IFileSystemFactory
+public sealed class FileSystemFactory(IAssemblyResourceService assemblyResourceService)
+    : IFileSystemFactory
 {
-    private readonly IAssemblyResourceService _assemblyResourceService;
-
-    public FileSystemFactory(IAssemblyResourceService assemblyResourceService)
-    {
-        _assemblyResourceService = assemblyResourceService;
-    }
-        
     public IFileSystem Create(string path)
     {
-        return new AggregateFileSystem(new[]
-        {
+        return new AggregateFileSystem([
             new DiskFileSystem(path),
-            _assemblyResourceService.GetFromAssemblyOf<IEngine>().Root
-        });
+            assemblyResourceService.GetFromAssemblyOf<IEngine>().Root
+        ]);
     }
 }

--- a/Source/Lyon/App/Impl/Launcher.cs
+++ b/Source/Lyon/App/Impl/Launcher.cs
@@ -3,26 +3,17 @@ using Lyon.Presenters;
 using Roton;
 using Roton.Emulation.Core;
 using Roton.Infrastructure;
-using Roton.Infrastructure.Impl;
 
 namespace Lyon.App.Impl;
 
 [Context(Context.Startup)]
-public sealed class Launcher : ILauncher
+public sealed class Launcher(
+    IWindow window,
+    IAudioPresenter audioPresenter)
+    : ILauncher
 {
-    private readonly IWindow _window;
-    private readonly IAudioPresenter _audioPresenter;
-
-    public Launcher(
-        IWindow window,
-        IAudioPresenter audioPresenter)
-    {
-        _window = window;
-        _audioPresenter = audioPresenter;
-    }
-
-    private IWindow Window => _window;
-    private IAudioPresenter AudioPresenter => _audioPresenter;
+    private IWindow Window => window;
+    private IAudioPresenter AudioPresenter => audioPresenter;
 
     private void OnExited(object sender, EventArgs e)
     {

--- a/Source/Lyon/App/Impl/Window.cs
+++ b/Source/Lyon/App/Impl/Window.cs
@@ -1,53 +1,114 @@
-﻿using System;
-using DotSDL.Events;
-using DotSDL.Graphics;
-using Lyon.Presenters;
+﻿using Lyon.Presenters;
 using Roton;
 using Roton.Emulation.Data;
 using Roton.Infrastructure;
-using Roton.Infrastructure.Impl;
 
 namespace Lyon.App.Impl;
 
 [Context(Context.Startup)]
-public sealed class Window : SdlWindow, IWindow
+public sealed unsafe class Window : IWindow
 {
+    private readonly SDL_Window* _window;
+    private readonly SDL_Renderer* _renderer;
+    private readonly SDL_Texture* _background;
     private readonly IKeyboardPresenter _keyboardPresenter;
     private readonly IScenePresenter _scenePresenter;
-    private bool _closeWindow;
 
-    private IKeyboardPresenter KeyboardPresenter => _keyboardPresenter;
-    private IScenePresenter ScenePresenter => _scenePresenter;
+    private bool _closeWindow;
 
     public Window(
         IConfig config,
         IKeyboardPresenter keyboardPresenter,
-        IScenePresenter scenePresenter) : base("Lyon",
-        new Point {X = WindowPosUndefined, Y = WindowPosUndefined},
-        (int)(640 * config.VideoScaleX), (int)(350 * config.VideoScaleY),
-        640, 350)
+        IScenePresenter scenePresenter)
     {
+        Title = "Lyon";
+        WindowWidth = (int)(640 * config.VideoScaleX);
+        WindowHeight = (int)(350 * config.VideoScaleY);
+        RenderWidth = 640;
+        RenderHeight = 350;
+
         _keyboardPresenter = keyboardPresenter;
         _scenePresenter = scenePresenter;
-        KeyPressed += OnKeyDown;
-        Closed += OnClosed;
 
-        ScalingQuality = ScalingQuality.PixelArt;
+        SDL_Init(SDL_InitFlags.SDL_INIT_VIDEO);
 
-        Background.GetCanvasPointer = () => {
-            var bitmap = ScenePresenter.Render();
-            return bitmap.Bits.Length == 0 ? IntPtr.Zero : bitmap.BitsPointer;
-        };
+        SDL_Window* window;
+        SDL_Renderer* renderer;
+
+        SDL_CreateWindowAndRenderer(Title, WindowWidth, WindowHeight,
+            SDL_WindowFlags.SDL_WINDOW_HIDDEN, &window, &renderer);
+
+        _window = window;
+        _renderer = renderer;
+
+        _background = SDL_CreateTexture(
+            _renderer,
+            SDL_PIXELFORMAT_BGRA32,
+            SDL_TextureAccess.SDL_TEXTUREACCESS_STREAMING,
+            RenderWidth,
+            RenderHeight
+        );
+
+        SDL_SetTextureScaleMode(_background, SDL_ScaleMode.SDL_SCALEMODE_PIXELART);
+        SDL_SetRenderVSync(renderer, 1);
     }
 
-    private void OnClosed(object sender, WindowEvent e)
+    public int RenderWidth { get; }
+
+    public int RenderHeight { get; }
+
+    public int WindowWidth { get; }
+
+    public int WindowHeight { get; }
+
+    public string Title { get; }
+
+    public bool Running { get; private set; }
+
+    private void Loop(float rate)
     {
-        Close();
+        SDL_ShowWindow(_window);
+        Running = true;
+
+        while (Running)
+        {
+            SDL_Event e;
+
+            while (SDL_PollEvent(&e))
+            {
+                switch (e.Type)
+                {
+                    case SDL_EventType.SDL_EVENT_QUIT:
+                    case SDL_EventType.SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+                        Close();
+                        break;
+                    case SDL_EventType.SDL_EVENT_KEY_DOWN:
+                        _keyboardPresenter.Press(e.key);
+                        break;
+                    case SDL_EventType.SDL_EVENT_KEY_UP:
+                        _keyboardPresenter.Release(e.key);
+                        break;
+                }
+            }
+
+            var bitmap = _scenePresenter.Render();
+            if (bitmap.Bits.Length > 0)
+                SDL_UpdateTexture(_background, null, bitmap.BitsPointer, RenderWidth * 4);
+
+            SDL_RenderTexture(_renderer, _background, null, null);
+            SDL_RenderPresent(_renderer);
+
+            if (_closeWindow)
+                break;
+        }
+
+        Running = false;
+        SDL_DestroyWindow(_window);
     }
 
     public void SetSize(int width, int height)
     {
-        ScenePresenter.UpdateViewport();
+        _scenePresenter.UpdateViewport();
     }
 
     public void Close()
@@ -55,19 +116,8 @@ public sealed class Window : SdlWindow, IWindow
         _closeWindow = true;
     }
 
-    private void OnKeyDown(object obj, KeyboardEvent e)
+    public void Start(float rate)
     {
-        KeyboardPresenter.Press(e);
-    }
-
-    private void OnKeyUp(object obj, KeyboardEvent e)
-    {
-        KeyboardPresenter.Release(e);
-    }
-
-    protected override void OnUpdate(float delta)
-    {
-        if(_closeWindow)
-            Stop();
+        Loop(rate);
     }
 }

--- a/Source/Lyon/App/Impl/Window.cs
+++ b/Source/Lyon/App/Impl/Window.cs
@@ -35,12 +35,15 @@ public sealed unsafe class Window : IWindow
         SDL_Window* window;
         SDL_Renderer* renderer;
 
+        // Create the window and renderer. The window starts hidden
+        // so we can show it when we are ready to render.
         SDL_CreateWindowAndRenderer(Title, WindowWidth, WindowHeight,
             SDL_WindowFlags.SDL_WINDOW_HIDDEN, &window, &renderer);
 
         _window = window;
         _renderer = renderer;
 
+        // Create the background texture to which we will render the scene.
         _background = SDL_CreateTexture(
             _renderer,
             SDL_PIXELFORMAT_BGRA32,
@@ -50,7 +53,11 @@ public sealed unsafe class Window : IWindow
         );
 
         SDL_SetTextureScaleMode(_background, SDL_ScaleMode.SDL_SCALEMODE_PIXELART);
-        SDL_SetRenderVSync(renderer, 1);
+
+        // Not all adapters support adaptive vsync, so use the regular
+        // method if this fails.
+        if (!SDL_SetRenderVSync(renderer, SDL_RENDERER_VSYNC_ADAPTIVE))
+            SDL_SetRenderVSync(renderer, 1);
     }
 
     public int RenderWidth { get; }

--- a/Source/Lyon/Globals.cs
+++ b/Source/Lyon/Globals.cs
@@ -1,0 +1,2 @@
+global using SDL;
+global using static SDL.SDL3;

--- a/Source/Lyon/Lyon.csproj
+++ b/Source/Lyon/Lyon.csproj
@@ -7,7 +7,6 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\Include\DotSDL\DotSDL\DotSDL.csproj" />
         <ProjectReference Include="..\Roton\Roton.csproj"/>
     </ItemGroup>
     <ItemGroup>

--- a/Source/Lyon/Presenters/IAudioPresenter.cs
+++ b/Source/Lyon/Presenters/IAudioPresenter.cs
@@ -4,7 +4,7 @@ namespace Lyon.Presenters;
 
 public interface IAudioPresenter
 {
-    double Volume { get; set; }
+    float Volume { get; set; }
     void Start();
     void Stop();
     void Update(AudioComposerDataEventArgs buffer);

--- a/Source/Lyon/Presenters/IKeyboardPresenter.cs
+++ b/Source/Lyon/Presenters/IKeyboardPresenter.cs
@@ -1,5 +1,4 @@
-﻿using DotSDL.Events;
-using Roton.Emulation.Core;
+﻿using Roton.Emulation.Core;
 
 namespace Lyon.Presenters;
 

--- a/Source/Lyon/Presenters/IKeyboardPresenter.cs
+++ b/Source/Lyon/Presenters/IKeyboardPresenter.cs
@@ -5,6 +5,6 @@ namespace Lyon.Presenters;
 
 public interface IKeyboardPresenter : IKeyboard
 {
-    bool Press(KeyboardEvent data);
-    void Release(KeyboardEvent data);
+    bool Press(SDL_KeyboardEvent data);
+    void Release(SDL_KeyboardEvent data);
 }

--- a/Source/Lyon/Presenters/Impl/AudioPresenter.cs
+++ b/Source/Lyon/Presenters/Impl/AudioPresenter.cs
@@ -62,20 +62,23 @@ public sealed unsafe class AudioPresenter : IDisposable, IAudioPresenter
 
         // We ask for 2x the buffer size so that there's a double
         // buffer of audio data.
-        var have = presenter._buffer.Count;
         var want = required / sizeof(float) * 2;
-
-        if (have < want)
-        {
-            Console.WriteLine($"Audio buffer underflow: need {want}, got {have}");
-            return;
-        }
-
         var floats = (stackalloc float[want]);
-        var count = Math.Min(have, floats.Length);
+        int count;
 
-        for (var i = 0; i < count; i++)
-            floats[i] = presenter._buffer.Dequeue();
+        lock (presenter._bufferLock)
+        {
+            var have = presenter._buffer.Count;
+            if (have < want)
+            {
+                Console.WriteLine($"Audio buffer underflow: need {want}, got {have}");
+                return;
+            }
+
+            count = Math.Min(have, floats.Length);
+            for (var i = 0; i < count; i++)
+                floats[i] = presenter._buffer.Dequeue();
+        }
 
         fixed (float* floatsPtr = floats)
             SDL_PutAudioStreamData(stream, (IntPtr)floatsPtr, count * sizeof(float));

--- a/Source/Lyon/Presenters/Impl/AudioPresenter.cs
+++ b/Source/Lyon/Presenters/Impl/AudioPresenter.cs
@@ -60,15 +60,18 @@ public sealed unsafe class AudioPresenter : IDisposable, IAudioPresenter
         if (!Presenters.TryGetValue((nint)stream, out var presenter))
             return;
 
-        var floats = (stackalloc float[required / sizeof(float)]);
+        // We ask for 2x the buffer size so that there's a double
+        // buffer of audio data.
         var have = presenter._buffer.Count;
+        var want = required / sizeof(float) * 2;
 
-        if (have < floats.Length * 2)
+        if (have < want)
         {
-            Console.WriteLine($"Audio buffer underflow: need {floats.Length}, got {have}");
+            Console.WriteLine($"Audio buffer underflow: need {want}, got {have}");
             return;
         }
 
+        var floats = (stackalloc float[want]);
         var count = Math.Min(have, floats.Length);
 
         for (var i = 0; i < count; i++)

--- a/Source/Lyon/Presenters/Impl/AudioPresenter.cs
+++ b/Source/Lyon/Presenters/Impl/AudioPresenter.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
-using DotSDL.Audio;
 using Roton;
 using Roton.Composers.Audio;
 using Roton.Emulation.Core;
@@ -13,46 +14,68 @@ namespace Lyon.Presenters.Impl;
 
 [Context(Context.Startup)]
 // ReSharper disable once UnusedMember.Global
-public sealed class AudioPresenter : IDisposable, IAudioPresenter
+public sealed unsafe class AudioPresenter : IDisposable, IAudioPresenter
 {
     private bool _isDisposed;
     private bool _running;
-    private readonly Queue<double> _buffer;
+    private readonly Queue<float> _buffer;
     private readonly Lock _bufferLock = new();
-    private readonly Playback _audio;
+    private readonly SDL_AudioStream* _stream;
+    private static readonly Dictionary<nint, AudioPresenter> Presenters = [];
 
     public AudioPresenter(IConfig config, IEngine engine, IAudioComposer composer)
     {
         _buffer = [];
-        _audio = new Playback(config.AudioSampleRate, AudioFormat.Integer16, ChannelCount.Mono,
-            (ushort)config.AudioBufferSize);
-        Volume = 0.1;
+
+        SampleRate = config.AudioSampleRate;
+        var spec = new SDL_AudioSpec
+        {
+            channels = 1,
+            format = SDL_AUDIO_F32,
+            freq = config.AudioSampleRate
+        };
+
+        // Create the audio stream.
+        if (!SDL_Init(SDL_InitFlags.SDL_INIT_AUDIO))
+            throw new Exception($"Failed to initialize SDL audio subsystem: {SDL_GetError()}");
+
+        _stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, &OnCallback, 0);
+        if (_stream == null)
+            throw new Exception($"Failed to create audio stream: {SDL_GetError()}");
+
+        Presenters.Add((nint)_stream, this);
+        Volume = 0.1f;
 
         composer.BufferReady += (_, a) => Update(a);
         composer.SampleRate = SampleRate;
+
         Start();
 
         engine.Tick += (_, _) => composer.Tick();
-
-        _audio.BufferEmpty += BufferEmpty;
-        _audio.Play();
     }
 
-    private void BufferEmpty(object sender, AudioBuffer e)
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnCallback(nint userData, SDL_AudioStream* stream, int required, int total)
     {
-        lock (_bufferLock)
+        if (!Presenters.TryGetValue((nint)stream, out var presenter))
+            return;
+
+        var floats = (stackalloc float[required / sizeof(float)]);
+        var have = presenter._buffer.Count;
+
+        if (have < floats.Length * 2)
         {
-            if (_buffer.Count < e.Length)
-            {
-                Debug.WriteLine($"Audio buffer underflow: need {e.Length}, got {_buffer.Count}");
-                return;
-            }
-
-            var count = Math.Min(_buffer.Count, e.Length);
-
-            for (var i = 0; i < count; i++)
-                e.Samples[Channel.Mono][i] = _buffer.Dequeue();
+            Console.WriteLine($"Audio buffer underflow: need {floats.Length}, got {have}");
+            return;
         }
+
+        var count = Math.Min(have, floats.Length);
+
+        for (var i = 0; i < count; i++)
+            floats[i] = presenter._buffer.Dequeue();
+
+        fixed (float* floatsPtr = floats)
+            SDL_PutAudioStreamData(stream, (IntPtr)floatsPtr, count * sizeof(float));
     }
 
     public void Start()
@@ -60,6 +83,7 @@ public sealed class AudioPresenter : IDisposable, IAudioPresenter
         if (_running)
             return;
 
+        SDL_ResumeAudioStreamDevice(_stream);
         _running = true;
     }
 
@@ -77,11 +101,11 @@ public sealed class AudioPresenter : IDisposable, IAudioPresenter
             foreach (var sample in data)
                 _buffer.Enqueue(sample * Volume);
         }
-        
+
         e.Memory.Dispose();
     }
 
-    public int SampleRate => _audio.Frequency;
+    public int SampleRate { get; private set; }
 
     public void Stop()
     {
@@ -91,7 +115,7 @@ public sealed class AudioPresenter : IDisposable, IAudioPresenter
         _running = false;
     }
 
-    public double Volume { get; set; }
+    public float Volume { get; set; }
 
     public void Dispose()
     {
@@ -100,6 +124,6 @@ public sealed class AudioPresenter : IDisposable, IAudioPresenter
 
         _isDisposed = true;
         Stop();
-        _audio.Close();
+        SDL_QuitSubSystem(SDL_InitFlags.SDL_INIT_AUDIO);
     }
 }

--- a/Source/Lyon/Presenters/Impl/AudioPresenter.cs
+++ b/Source/Lyon/Presenters/Impl/AudioPresenter.cs
@@ -1,17 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using DotSDL.Audio;
 using Roton;
 using Roton.Composers.Audio;
-using Roton.Composers.Audio.Impl;
 using Roton.Emulation.Core;
 using Roton.Emulation.Data;
 using Roton.Infrastructure;
-using Roton.Infrastructure.Impl;
 
 namespace Lyon.Presenters.Impl;
 

--- a/Source/Lyon/Presenters/Impl/KeyboardPresenter.cs
+++ b/Source/Lyon/Presenters/Impl/KeyboardPresenter.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using DotSDL.Events;
-using DotSDL.Input.Keyboard;
 using Roton;
 using Roton.Emulation.Core;
 using Roton.Infrastructure;

--- a/Source/Lyon/Presenters/Impl/KeyboardPresenter.cs
+++ b/Source/Lyon/Presenters/Impl/KeyboardPresenter.cs
@@ -3,9 +3,7 @@ using DotSDL.Events;
 using DotSDL.Input.Keyboard;
 using Roton;
 using Roton.Emulation.Core;
-using Roton.Emulation.Core.Impl;
 using Roton.Infrastructure;
-using Roton.Infrastructure.Impl;
 using Keyboard = Roton.Emulation.Core.Impl.Keyboard;
 
 namespace Lyon.Presenters.Impl;
@@ -14,128 +12,137 @@ namespace Lyon.Presenters.Impl;
 // ReSharper disable once UnusedMember.Global
 public sealed class KeyboardPresenter : Keyboard, IKeyboardPresenter
 {
-    private static readonly IDictionary<Keycode, AnsiKey> Map = new Dictionary<Keycode, AnsiKey>
+    private static readonly IDictionary<SDL_Keycode, AnsiKey> Map = new Dictionary<SDL_Keycode, AnsiKey>
     {
-        { Keycode.A, AnsiKey.A },
-        { Keycode.B, AnsiKey.B },
-        { Keycode.C, AnsiKey.C },
-        { Keycode.D, AnsiKey.D },
-        { Keycode.E, AnsiKey.E },
-        { Keycode.F, AnsiKey.F },
-        { Keycode.G, AnsiKey.G },
-        { Keycode.H, AnsiKey.H },
-        { Keycode.I, AnsiKey.I },
-        { Keycode.J, AnsiKey.J },
-        { Keycode.K, AnsiKey.K },
-        { Keycode.L, AnsiKey.L },
-        { Keycode.M, AnsiKey.M },
-        { Keycode.N, AnsiKey.N },
-        { Keycode.O, AnsiKey.O },
-        { Keycode.P, AnsiKey.P },
-        { Keycode.Q, AnsiKey.Q },
-        { Keycode.R, AnsiKey.R },
-        { Keycode.S, AnsiKey.S },
-        { Keycode.T, AnsiKey.T },
-        { Keycode.U, AnsiKey.U },
-        { Keycode.V, AnsiKey.V },
-        { Keycode.W, AnsiKey.W },
-        { Keycode.X, AnsiKey.X },
-        { Keycode.Y, AnsiKey.Y },
-        { Keycode.Z, AnsiKey.Z },
-        { Keycode.Quote, AnsiKey.Apostophe },
-        { Keycode.Backslash, AnsiKey.Backslash },
-        { Keycode.Backspace, AnsiKey.Backspace },
-        { Keycode.Comma, AnsiKey.Comma },
-        { Keycode.Num0, AnsiKey.D0 },
-        { Keycode.Num1, AnsiKey.D1 },
-        { Keycode.Num2, AnsiKey.D2 },
-        { Keycode.Num3, AnsiKey.D3 },
-        { Keycode.Num4, AnsiKey.D4 },
-        { Keycode.Num5, AnsiKey.D5 },
-        { Keycode.Num6, AnsiKey.D6 },
-        { Keycode.Num7, AnsiKey.D7 },
-        { Keycode.Num8, AnsiKey.D8 },
-        { Keycode.Num9, AnsiKey.D9 },
-        { Keycode.Delete, AnsiKey.Delete },
-        { Keycode.Down, AnsiKey.Down },
-        { Keycode.End, AnsiKey.End },
-        { Keycode.Return, AnsiKey.Enter },
-        { Keycode.Plus, AnsiKey.Equals },
-        { Keycode.Escape, AnsiKey.Escape },
-        { Keycode.F1, AnsiKey.F1 },
-        { Keycode.F2, AnsiKey.F2 },
-        { Keycode.F3, AnsiKey.F3 },
-        { Keycode.F4, AnsiKey.F4 },
-        { Keycode.F5, AnsiKey.F5 },
-        { Keycode.F6, AnsiKey.F6 },
-        { Keycode.F7, AnsiKey.F7 },
-        { Keycode.F8, AnsiKey.F8 },
-        { Keycode.F9, AnsiKey.F9 },
-        { Keycode.F10, AnsiKey.F10 },
-        { Keycode.F11, AnsiKey.F11 },
-        { Keycode.F12, AnsiKey.F12 },
-        { Keycode.Backquote, AnsiKey.Grave },
-        { Keycode.Home, AnsiKey.Home },
-        { Keycode.Insert, AnsiKey.Insert },
-        { Keycode.Left, AnsiKey.Left },
-        { Keycode.LeftBracket, AnsiKey.LeftSquare },
-        { Keycode.Minus, AnsiKey.Minus },
-        { Keycode.NumPad0, AnsiKey.Num0 },
-        { Keycode.NumPad1, AnsiKey.Num1 },
-        { Keycode.NumPad2, AnsiKey.Num2 },
-        { Keycode.NumPad3, AnsiKey.Num3 },
-        { Keycode.NumPad4, AnsiKey.Num4 },
-        { Keycode.NumPad5, AnsiKey.Num5 },
-        { Keycode.NumPad6, AnsiKey.Num6 },
-        { Keycode.NumPad7, AnsiKey.Num7 },
-        { Keycode.NumPad8, AnsiKey.Num8 },
-        { Keycode.NumPad9, AnsiKey.Num9 },
-        { Keycode.NumPadEnter, AnsiKey.NumEnter },
-        { Keycode.NumPadMinus, AnsiKey.NumMinus },
-        { Keycode.NumPadPeriod, AnsiKey.NumPeriod },
-        { Keycode.NumPadPlus, AnsiKey.NumPlus },
-        { Keycode.NumPadDivide, AnsiKey.NumSlash },
-        { Keycode.NumPadMultiply, AnsiKey.NumStar },
-        { Keycode.PageDown, AnsiKey.PageDown },
-        { Keycode.PageUp, AnsiKey.PageUp },
-        { Keycode.Pause, AnsiKey.Pause },
-        { Keycode.Period, AnsiKey.Period },
-        { Keycode.PrintScreen, AnsiKey.PrintScreen },
-        { Keycode.Right, AnsiKey.Right },
-        { Keycode.RightBracket, AnsiKey.RightSquare },
-        { Keycode.Semicolon, AnsiKey.Semicolon },
-        { Keycode.Slash, AnsiKey.Slash },
-        { Keycode.Space, AnsiKey.Space },
-        { Keycode.Tab, AnsiKey.Tab },
-        { Keycode.Up, AnsiKey.Up },
-        { Keycode.Question, AnsiKey.Slash },
-        { Keycode.Equals, AnsiKey.Equals }
+        { SDL_Keycode.SDLK_A, AnsiKey.A },
+        { SDL_Keycode.SDLK_B, AnsiKey.B },
+        { SDL_Keycode.SDLK_C, AnsiKey.C },
+        { SDL_Keycode.SDLK_D, AnsiKey.D },
+        { SDL_Keycode.SDLK_E, AnsiKey.E },
+        { SDL_Keycode.SDLK_F, AnsiKey.F },
+        { SDL_Keycode.SDLK_G, AnsiKey.G },
+        { SDL_Keycode.SDLK_H, AnsiKey.H },
+        { SDL_Keycode.SDLK_I, AnsiKey.I },
+        { SDL_Keycode.SDLK_J, AnsiKey.J },
+        { SDL_Keycode.SDLK_K, AnsiKey.K },
+        { SDL_Keycode.SDLK_L, AnsiKey.L },
+        { SDL_Keycode.SDLK_M, AnsiKey.M },
+        { SDL_Keycode.SDLK_N, AnsiKey.N },
+        { SDL_Keycode.SDLK_O, AnsiKey.O },
+        { SDL_Keycode.SDLK_P, AnsiKey.P },
+        { SDL_Keycode.SDLK_Q, AnsiKey.Q },
+        { SDL_Keycode.SDLK_R, AnsiKey.R },
+        { SDL_Keycode.SDLK_S, AnsiKey.S },
+        { SDL_Keycode.SDLK_T, AnsiKey.T },
+        { SDL_Keycode.SDLK_U, AnsiKey.U },
+        { SDL_Keycode.SDLK_V, AnsiKey.V },
+        { SDL_Keycode.SDLK_W, AnsiKey.W },
+        { SDL_Keycode.SDLK_X, AnsiKey.X },
+        { SDL_Keycode.SDLK_Y, AnsiKey.Y },
+        { SDL_Keycode.SDLK_Z, AnsiKey.Z },
+        { SDL_Keycode.SDLK_APOSTROPHE, AnsiKey.Apostophe },
+        { SDL_Keycode.SDLK_BACKSLASH, AnsiKey.Backslash },
+        { SDL_Keycode.SDLK_BACKSPACE, AnsiKey.Backspace },
+        { SDL_Keycode.SDLK_COMMA, AnsiKey.Comma },
+        { SDL_Keycode.SDLK_0, AnsiKey.D0 },
+        { SDL_Keycode.SDLK_1, AnsiKey.D1 },
+        { SDL_Keycode.SDLK_2, AnsiKey.D2 },
+        { SDL_Keycode.SDLK_3, AnsiKey.D3 },
+        { SDL_Keycode.SDLK_4, AnsiKey.D4 },
+        { SDL_Keycode.SDLK_5, AnsiKey.D5 },
+        { SDL_Keycode.SDLK_6, AnsiKey.D6 },
+        { SDL_Keycode.SDLK_7, AnsiKey.D7 },
+        { SDL_Keycode.SDLK_8, AnsiKey.D8 },
+        { SDL_Keycode.SDLK_9, AnsiKey.D9 },
+        { SDL_Keycode.SDLK_DELETE, AnsiKey.Delete },
+        { SDL_Keycode.SDLK_DOWN, AnsiKey.Down },
+        { SDL_Keycode.SDLK_END, AnsiKey.End },
+        { SDL_Keycode.SDLK_RETURN, AnsiKey.Enter },
+        { SDL_Keycode.SDLK_PLUS, AnsiKey.Equals },
+        { SDL_Keycode.SDLK_ESCAPE, AnsiKey.Escape },
+        { SDL_Keycode.SDLK_F1, AnsiKey.F1 },
+        { SDL_Keycode.SDLK_F2, AnsiKey.F2 },
+        { SDL_Keycode.SDLK_F3, AnsiKey.F3 },
+        { SDL_Keycode.SDLK_F4, AnsiKey.F4 },
+        { SDL_Keycode.SDLK_F5, AnsiKey.F5 },
+        { SDL_Keycode.SDLK_F6, AnsiKey.F6 },
+        { SDL_Keycode.SDLK_F7, AnsiKey.F7 },
+        { SDL_Keycode.SDLK_F8, AnsiKey.F8 },
+        { SDL_Keycode.SDLK_F9, AnsiKey.F9 },
+        { SDL_Keycode.SDLK_F10, AnsiKey.F10 },
+        { SDL_Keycode.SDLK_F11, AnsiKey.F11 },
+        { SDL_Keycode.SDLK_F12, AnsiKey.F12 },
+        { SDL_Keycode.SDLK_GRAVE, AnsiKey.Grave },
+        { SDL_Keycode.SDLK_HOME, AnsiKey.Home },
+        { SDL_Keycode.SDLK_INSERT, AnsiKey.Insert },
+        { SDL_Keycode.SDLK_LEFT, AnsiKey.Left },
+        { SDL_Keycode.SDLK_LEFTBRACKET, AnsiKey.LeftSquare },
+        { SDL_Keycode.SDLK_MINUS, AnsiKey.Minus },
+        { SDL_Keycode.SDLK_KP_0, AnsiKey.D0 },
+        { SDL_Keycode.SDLK_KP_1, AnsiKey.D1 },
+        { SDL_Keycode.SDLK_KP_2, AnsiKey.D2 },
+        { SDL_Keycode.SDLK_KP_3, AnsiKey.D3 },
+        { SDL_Keycode.SDLK_KP_4, AnsiKey.D4 },
+        { SDL_Keycode.SDLK_KP_5, AnsiKey.D5 },
+        { SDL_Keycode.SDLK_KP_6, AnsiKey.D6 },
+        { SDL_Keycode.SDLK_KP_7, AnsiKey.D7 },
+        { SDL_Keycode.SDLK_KP_8, AnsiKey.D8 },
+        { SDL_Keycode.SDLK_KP_9, AnsiKey.D9 },
+        { SDL_Keycode.SDLK_KP_ENTER, AnsiKey.NumEnter },
+        { SDL_Keycode.SDLK_KP_MINUS, AnsiKey.NumMinus },
+        { SDL_Keycode.SDLK_KP_PERIOD, AnsiKey.NumPeriod },
+        { SDL_Keycode.SDLK_KP_PLUS, AnsiKey.NumPlus },
+        { SDL_Keycode.SDLK_KP_DIVIDE, AnsiKey.NumSlash },
+        { SDL_Keycode.SDLK_KP_MULTIPLY, AnsiKey.NumStar },
+        { SDL_Keycode.SDLK_PAGEDOWN, AnsiKey.PageDown },
+        { SDL_Keycode.SDLK_PAGEUP, AnsiKey.PageUp },
+        { SDL_Keycode.SDLK_PAUSE, AnsiKey.Pause },
+        { SDL_Keycode.SDLK_PERIOD, AnsiKey.Period },
+        { SDL_Keycode.SDLK_PRINTSCREEN, AnsiKey.PrintScreen },
+        { SDL_Keycode.SDLK_RIGHT, AnsiKey.Right },
+        { SDL_Keycode.SDLK_RIGHTBRACKET, AnsiKey.RightSquare },
+        { SDL_Keycode.SDLK_SEMICOLON, AnsiKey.Semicolon },
+        { SDL_Keycode.SDLK_SLASH, AnsiKey.Slash },
+        { SDL_Keycode.SDLK_SPACE, AnsiKey.Space },
+        { SDL_Keycode.SDLK_TAB, AnsiKey.Tab },
+        { SDL_Keycode.SDLK_UP, AnsiKey.Up },
+        { SDL_Keycode.SDLK_QUESTION, AnsiKey.Slash },
+        { SDL_Keycode.SDLK_EQUALS, AnsiKey.Equals }
     };
 
-    private static KeyMod ConvertKeyMod(Keymod mod) =>
-        (mod.HasFlag(Keymod.LShift) | mod.HasFlag(Keymod.RShift) ? KeyMod.Shift : 0) |
-        (mod.HasFlag(Keymod.LCtrl) | mod.HasFlag(Keymod.RCtrl) ? KeyMod.Control : 0) |
-        (mod.HasFlag(Keymod.LAlt) | mod.HasFlag(Keymod.RAlt) ? KeyMod.Alt : 0);
+    private static KeyMod ConvertKeyMod(SDL_Keymod mod) =>
+        (mod.HasFlag(SDL_Keymod.SDL_KMOD_LSHIFT) |
+         mod.HasFlag(SDL_Keymod.SDL_KMOD_RSHIFT)
+            ? KeyMod.Shift
+            : 0) |
+        (mod.HasFlag(SDL_Keymod.SDL_KMOD_LCTRL) |
+         mod.HasFlag(SDL_Keymod.SDL_KMOD_RCTRL)
+            ? KeyMod.Control
+            : 0) |
+        (mod.HasFlag(SDL_Keymod.SDL_KMOD_LALT) |
+         mod.HasFlag(SDL_Keymod.SDL_KMOD_RALT)
+            ? KeyMod.Alt
+            : 0);
 
-    private KeyMod UpdateMod(KeyboardEvent data)
+    private KeyMod UpdateMod(SDL_KeyboardEvent data)
     {
-        var newMod = ConvertKeyMod(data.Keymod);
+        var newMod = ConvertKeyMod(data.mod);
         SetMod(newMod);
         return newMod;
     }
 
-    public bool Press(KeyboardEvent data)
+    public bool Press(SDL_KeyboardEvent data)
     {
         var newMod = UpdateMod(data);
 
-        if (data.Keycode == 0)
+        if (data.key == 0)
             return false;
 
         // Don't process command/Windows key shortcuts.
-        if ((data.Keymod & Keymod.Gui) != 0)
+        if ((data.mod & SDL_Keymod.SDL_KMOD_GUI) != 0)
             return false;
 
-        if (!Map.TryGetValue(data.Keycode, out var value))
+        if (!Map.TryGetValue(data.key, out var value))
             return false;
 
         Enqueue(new KeyPress
@@ -147,7 +154,7 @@ public sealed class KeyboardPresenter : Keyboard, IKeyboardPresenter
         return true;
     }
 
-    public void Release(KeyboardEvent data)
+    public void Release(SDL_KeyboardEvent data)
     {
         UpdateMod(data);
     }

--- a/Source/Lyon/Presenters/Impl/ScenePresenter.cs
+++ b/Source/Lyon/Presenters/Impl/ScenePresenter.cs
@@ -1,7 +1,6 @@
 ﻿using Roton;
 using Roton.Composers.Video.Scenes;
 using Roton.Infrastructure;
-using Roton.Infrastructure.Impl;
 
 namespace Lyon.Presenters.Impl;
 

--- a/Source/Roton.sln
+++ b/Source/Roton.sln
@@ -9,8 +9,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lyon", "Lyon\Lyon.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Roton.Test", "Roton.Test\Roton.Test.csproj", "{F87DC9C8-B22C-4A29-AB64-D529828950DE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotSDL", "..\Include\DotSDL\DotSDL\DotSDL.csproj", "{2F20D667-6C59-4637-B4FF-E1A8802418E2}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Files", "Files", "{ABB83496-AE05-4036-947B-9E1BACFF9218}"
 	ProjectSection(SolutionItems) = preProject
 		..\.gitignore = ..\.gitignore
@@ -41,10 +39,6 @@ Global
 		{F87DC9C8-B22C-4A29-AB64-D529828950DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F87DC9C8-B22C-4A29-AB64-D529828950DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F87DC9C8-B22C-4A29-AB64-D529828950DE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2F20D667-6C59-4637-B4FF-E1A8802418E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2F20D667-6C59-4637-B4FF-E1A8802418E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2F20D667-6C59-4637-B4FF-E1A8802418E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2F20D667-6C59-4637-B4FF-E1A8802418E2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Roton/Composers/Video/Glyphs/IGlyph.cs
+++ b/Source/Roton/Composers/Video/Glyphs/IGlyph.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System;
 
 namespace Roton.Composers.Video.Glyphs;
 
@@ -7,5 +7,5 @@ public interface IGlyph
     int Index { get; }
     int Width { get; }
     int Height { get; }
-    IReadOnlyList<int> Data { get; }
+    ReadOnlySpan<int> Data { get; }
 }

--- a/Source/Roton/Composers/Video/Glyphs/Impl/Glyph.cs
+++ b/Source/Roton/Composers/Video/Glyphs/Impl/Glyph.cs
@@ -1,12 +1,14 @@
-using System.Collections.Generic;
+using System;
 
 namespace Roton.Composers.Video.Glyphs.Impl;
 
-public sealed class Glyph(int index, int width, int height, IEnumerable<int> data)
+public sealed class Glyph(int index, int width, int height, ReadOnlySpan<int> data)
     : IGlyph
 {
+    private readonly int[] _data = [.. data];
+    
     public int Index { get; } = index;
     public int Width { get; } = width;
     public int Height { get; } = height;
-    public IReadOnlyList<int> Data { get; } = [.. data];
+    public ReadOnlySpan<int> Data => _data;
 }

--- a/Source/Roton/Composers/Video/Glyphs/Impl/ScaledGlyphComposer.cs
+++ b/Source/Roton/Composers/Video/Glyphs/Impl/ScaledGlyphComposer.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace Roton.Composers.Video.Glyphs.Impl;
+﻿namespace Roton.Composers.Video.Glyphs.Impl;
 
 public sealed class ScaledGlyphComposer(IGlyphComposer glyphComposer, int scaleX, int scaleY) : IGlyphComposer
 {
@@ -9,10 +7,32 @@ public sealed class ScaledGlyphComposer(IGlyphComposer glyphComposer, int scaleX
         var glyph = glyphComposer.ComposeGlyph(index);
         if (glyph == null)
             return null;
-        
-        var scaledXScan = glyph.Data.SelectMany(pixel => Enumerable.Repeat(pixel, scaleX));
-        var scaledY = scaledXScan.SelectMany(scan => Enumerable.Repeat(scan, scaleY));
-        return new Glyph(index, glyph.Width * scaleX, glyph.Height * scaleY, scaledY);
+
+        var scaledRow = (stackalloc int[glyph.Width*scaleX]);
+        var scaledData = (stackalloc int[glyph.Data.Length*scaleX*scaleY]);
+        var src = 0;
+        var dest = 0;
+        var destBase = 0;
+
+        for (var y = 0; y < glyph.Height; y++)
+        {
+            dest = 0;
+
+            for (var x = 0; x < glyph.Width; x++)
+            {
+                var bits = glyph.Data[src++];
+                for (var i = 0; i < scaleX; i++)
+                    scaledRow[dest++] = bits;
+            }
+
+            for (var i = 0; i < scaleY; i++)
+            {
+                scaledRow.CopyTo(scaledData.Slice(destBase));
+                destBase += scaledRow.Length;
+            }
+        }
+
+        return new Glyph(index, glyph.Width * scaleX, glyph.Height * scaleY, scaledData);
     }
 
     public int MaxWidth { get; } = glyphComposer.MaxWidth*scaleX;

--- a/Source/Roton/Composers/Video/Scenes/Impl/SceneComposer.cs
+++ b/Source/Roton/Composers/Video/Scenes/Impl/SceneComposer.cs
@@ -1,5 +1,10 @@
 ﻿using System;
 using System.Linq;
+#if NET10_0_OR_GREATER
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+#endif
 using Roton.Composers.Video.Glyphs;
 using Roton.Composers.Video.Palettes;
 using Roton.Emulation.Data;
@@ -177,8 +182,24 @@ public sealed class SceneComposer : ISceneComposer, IDisposable
         var foregroundColor = !_hideBlinkingCharacters || (ac.Color & 0x80) == 0
             ? colors[ac.Color & 0x0F]
             : backgroundColor;
+#if NET10_0_OR_GREATER
+        var vFg = Vector128.Create(foregroundColor);
+        var vBg = Vector128.Create(backgroundColor);
+#endif
         for (var y = 0; y < height; y++)
         {
+#if NET10_0_OR_GREATER
+            var x = 0;
+            while (x <= width - 4)
+            {
+                var vIn = Vector128.LoadUnsafe(ref Unsafe.Add(ref MemoryMarshal.GetReference(inputBits), inputOffset));
+                Vector128.ConditionalSelect(vIn, vFg, vBg)
+                    .StoreUnsafe(ref outputBits[baseOffset + x]);
+                inputOffset += 4;
+                x += 4;
+            }
+            baseOffset += _stride;
+#else
             var outputOffset = baseOffset;
             for (var x = 0; x < width; x++)
             {
@@ -187,6 +208,7 @@ public sealed class SceneComposer : ISceneComposer, IDisposable
             }
 
             baseOffset += _stride;
+#endif
         }
 
         SceneUpdated?.Invoke(this, new SceneUpdatedEventArgs());

--- a/Source/Roton/Emulation/Core/IHud.cs
+++ b/Source/Roton/Emulation/Core/IHud.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Roton.Emulation.Data;
 
 namespace Roton.Emulation.Core;

--- a/Source/Roton/Emulation/Core/Impl/Engine.cs
+++ b/Source/Roton/Emulation/Core/Impl/Engine.cs
@@ -24,6 +24,8 @@ public sealed class Engine : IEngine, IDisposable
 {
     private readonly IConfigFileService _configFileService;
     private readonly IFileDialog _fileDialog;
+    private readonly Func<bool> _waitForTickFastDelegate;
+    private readonly Func<bool> _waitForTickNormalDelegate;
 
     private int _ticksToRun;
     private float _boardTimeHsec;
@@ -91,6 +93,9 @@ public sealed class Engine : IEngine, IDisposable
         _fileDialog = fileDialog;
         Tracer = tracer;
         _engineAccessor = engineAccessor;
+
+        _waitForTickFastDelegate = WaitForTickFastCondition;
+        _waitForTickNormalDelegate = WaitForTickNormalCondition;
     }
 
     private void ClockTick(object? sender, EventArgs args)
@@ -1420,23 +1425,28 @@ public sealed class Engine : IEngine, IDisposable
             State.SoundTicks--;
     }
 
+    private bool WaitForTickFastCondition()
+    {
+        if (_ticksToRun <= 0)
+            return true;
+
+        UpdateSound();
+        Tick?.Invoke(this, EventArgs.Empty);
+        _ticksToRun--;
+
+        return false;
+    }
+
+    private bool WaitForTickNormalCondition() => 
+        _ticksToRun > 0 || !ThreadActive;
+
     public void WaitForTick()
     {
         var isFast = State.GameWaitTime <= 0 && Config.FastMode;
 
         if (isFast)
         {
-            SpinWait.SpinUntil(() =>
-            {
-                if (_ticksToRun <= 0)
-                    return true;
-
-                UpdateSound();
-                Tick?.Invoke(this, EventArgs.Empty);
-                _ticksToRun--;
-
-                return false;
-            });
+            SpinWait.SpinUntil(_waitForTickFastDelegate);
         }
         else
         {
@@ -1444,7 +1454,7 @@ public sealed class Engine : IEngine, IDisposable
 
             Tick?.Invoke(this, EventArgs.Empty);
 
-            SpinWait.SpinUntil(() => _ticksToRun > 0 || !ThreadActive);
+            SpinWait.SpinUntil(_waitForTickNormalDelegate);
 
             if (_ticksToRun > 0)
                 _ticksToRun--;

--- a/Source/Roton/Emulation/Data/AnsiChar.cs
+++ b/Source/Roton/Emulation/Data/AnsiChar.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Roton.Emulation.Data;
 

--- a/Source/Roton/Emulation/Data/IExits.cs
+++ b/Source/Roton/Emulation/Data/IExits.cs
@@ -2,9 +2,9 @@ namespace Roton.Emulation.Data;
 
 public interface IExits
 {
-    int this[int index] { get; set; }
-    int East { get; set; }
-    int North { get; set; }
-    int South { get; set; }
-    int West { get; set; }
+    ref HWord this[int index] { get; }
+    ref HWord East { get; }
+    ref HWord North { get; }
+    ref HWord South { get; }
+    ref HWord West { get; }
 }

--- a/Source/Roton/Emulation/Data/Impl/CodeHeap.cs
+++ b/Source/Roton/Emulation/Data/Impl/CodeHeap.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Roton.Infrastructure;
 
 namespace Roton.Emulation.Data.Impl;

--- a/Source/Roton/Emulation/Original/OriginalExits.cs
+++ b/Source/Roton/Emulation/Original/OriginalExits.cs
@@ -6,34 +6,9 @@ namespace Roton.Emulation.Original;
 [Context(Context.Original)]
 public class OriginalExits(IMemory memory) : IExits
 {
-    public int this[int index]
-    {
-        get => memory.Read8(0x4569 + index);
-        set => memory.Write8(0x4569 + index, value);
-    }
-
-    public int East
-    {
-        get => memory.Read8(0x456C);
-        set => memory.Write8(0x456C, value);
-    }
-
-    public int North
-    {
-        get => memory.Read8(0x4569);
-        set => memory.Write8(0x4569, value);
-    }
-
-    public int South
-    {
-        get => memory.Read8(0x456A);
-        set => memory.Write8(0x456A, value);
-    }
-
-    public int West
-    {
-        get => memory.Read8(0x456B);
-        set => memory.Write8(0x456B, value);
-    }
-
+    public ref HWord this[int index] => ref memory.GetRef<HWord>(0x4569 + index);
+    public ref HWord East => ref memory.GetRef<HWord>(0x456C);
+    public ref HWord North => ref memory.GetRef<HWord>(0x4569);
+    public ref HWord South => ref memory.GetRef<HWord>(0x456A);
+    public ref HWord West => ref memory.GetRef<HWord>(0x456B);
 }

--- a/Source/Roton/Emulation/Super/SuperExits.cs
+++ b/Source/Roton/Emulation/Super/SuperExits.cs
@@ -6,33 +6,13 @@ namespace Roton.Emulation.Super;
 [Context(Context.Super)]
 public class SuperExits(IMemory memory) : IExits
 {
-    public int this[int index]
-    {
-        get => memory.Read8(index + 0x7768);
-        set => memory.Write8(index + 0x7768, value);
-    }
+    public ref HWord this[int index] => ref memory.GetRef<HWord>(0x7768 + index);
 
-    public int East
-    {
-        get => memory.Read8(0x776B);
-        set => memory.Write8(0x776B, value);
-    }
+    public ref HWord East => ref memory.GetRef<HWord>(0x776B);
 
-    public int North
-    {
-        get => memory.Read8(0x7768);
-        set => memory.Write8(0x7768, value);
-    }
+    public ref HWord North => ref memory.GetRef<HWord>(0x7768);
 
-    public int South
-    {
-        get => memory.Read8(0x7769);
-        set => memory.Write8(0x7769, value);
-    }
+    public ref HWord South => ref memory.GetRef<HWord>(0x7769);
 
-    public int West
-    {
-        get => memory.Read8(0x776A);
-        set => memory.Write8(0x776A, value);
-    }
+    public ref HWord West => ref memory.GetRef<HWord>(0x776A);
 }


### PR DESCRIPTION
- Fixed remaining performance issues in hot paths
- Use SIMD acceleration for glyph rendering if available
- DotSDL is removed, replaced with plain SDL3 calls (we were not using many of the features of it at all anyway)
- DotMemory shows no further GC pressure during runtime
- Change some IEnumerable/IReadOnlyList to ReadOnlySpan